### PR TITLE
Create AttackPhase Class

### DIFF
--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -161,7 +161,7 @@ attacker iff conqueredCount ≥ 1, regardless of how many territories were conqu
   - **State of the system**: conqueredCount = 1 (one conquest this turn); game.drawCard() mocked
   - **Expected output**: game.drawCard() called exactly once; attacker.addCard(card) called
 
-- **TC25: conqueredCount = 2 (above lower bound) → exactly one card drawn** ( :x: )
+- **TC25: conqueredCount = 2 (above lower bound) → exactly one card drawn** ( :white_check_mark: )
   - **State of the system**: conqueredCount = 2; game.drawCard() mocked
   - **Expected output**: game.drawCard() called exactly once (not twice)
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -106,7 +106,7 @@ later by moveInTroops). If no conquest, t.removeTroops(defenderLosses) is called
 
 **Post-battle conquest boundary (Count with 0 as conquest threshold):**
 
-- **TC17: no conquest — t has armies remaining after battle** ( :x: )
+- **TC17: no conquest — t has armies remaining after battle** ( :white_check_mark: )
   - **State of the system**: defenderLosses < t.getTroopCount(); mocked dice produce this outcome
   - **Expected output**: s.removeTroops(attackerLosses) called; t.removeTroops(defenderLosses)
     called; conqueredCount remains 0

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -56,7 +56,7 @@ constraint n ≤ s.getTroopCount() − 1 (source must retain at least 1 army aft
   - **State of the system**: s owned by attacker, s has 2 troops, s and t adjacent, t owned by enemy
   - **Expected output**: no exception; ownership and adjacency checks made on mocks
 
-- **TC9: n = 3 (upper bound), s.getTroopCount() = 4 → no exception** ( :x: )
+- **TC9: n = 3 (upper bound), s.getTroopCount() = 4 → no exception** ( :white_check_mark: )
   - **State of the system**: s owned by attacker, s has 4 troops, s and t adjacent, t owned by enemy
   - **Expected output**: no exception; ownership and adjacency checks made on mocks
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -176,6 +176,6 @@ awardCardIfEarned; BVA tests verify the observable effects through that delegati
   - **State of the system**: no conquests this turn
   - **Expected output**: game.drawCard() not called; attacker.addCard() not called
 
-- **TC27: endPhase with conqueredCount ≥ 1 → card drawn and given to attacker** ( :x: )
+- **TC27: endPhase with conqueredCount ≥ 1 → card drawn and given to attacker** ( :white_check_mark: )
   - **State of the system**: at least one conquest this turn; game.drawCard() mocked
   - **Expected output**: game.drawCard() called once; attacker.addCard(card) called

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -96,7 +96,7 @@ later by moveInTroops). If no conquest, t.removeTroops(defenderLosses) is called
 
 **Defender dice count (min(2, t.getTroopCount()), interval [1, 2]):**
 
-- **TC15: t.getTroopCount() = 1 (lower bound → defender rolls 1 die)** ( :x: )
+- **TC15: t.getTroopCount() = 1 (lower bound → defender rolls 1 die)** ( :white_check_mark: )
   - **State of the system**: t has 1 troop; diceRoller.rollDefender(1) mocked
   - **Expected output**: diceRoller.rollDefender(1) called; losses applied
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -80,7 +80,7 @@ constraint n ≤ s.getTroopCount() − 1 (source must retain at least 1 army aft
   - **State of the system**: game.getMap().areAdjacent(s, t) returns false
   - **Expected output**: IllegalArgumentException thrown
 
-- **TC14: t owned by attacker → IllegalArgumentException** ( :x: )
+- **TC14: t owned by attacker → IllegalArgumentException** ( :white_check_mark: )
   - **State of the system**: t.getOwner() returns the attacker
   - **Expected output**: IllegalArgumentException thrown
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -60,7 +60,7 @@ constraint n ≤ s.getTroopCount() − 1 (source must retain at least 1 army aft
   - **State of the system**: s owned by attacker, s has 4 troops, s and t adjacent, t owned by enemy
   - **Expected output**: no exception; ownership and adjacency checks made on mocks
 
-- **TC10: n = 4 (above upper bound) → IllegalArgumentException** ( :x: )
+- **TC10: n = 4 (above upper bound) → IllegalArgumentException** ( :white_check_mark: )
   - **State of the system**: valid s, t; n = 4
   - **Expected output**: IllegalArgumentException thrown
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -126,7 +126,7 @@ count from the preceding resolveBattle call (stored internally by AttackPhase).
 
 **n count (interval [lastAttackDice, s.getTroopCount() − 1]):**
 
-- **TC19: n < lastAttackDice (below lower bound) → IllegalArgumentException** ( :x: )
+- **TC19: n < lastAttackDice (below lower bound) → IllegalArgumentException** ( :white_check_mark: )
   - **State of the system**: lastAttackDice = 2; n = 1; s has 5 troops
   - **Expected output**: IllegalArgumentException thrown
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -1,0 +1,181 @@
+# AttackPhase - BVA Analysis
+
+### Constructor `AttackPhase(Player attacker, DiceRoller diceRoller, Game game)`
+
+Precondition: all arguments non-null. `conqueredCount` initializes to 0.
+
+- **TC1: valid arguments — conqueredCount initialized to 0** ( :x: )
+  - **State of the system**: attacker, diceRoller, game provided
+  - **Expected output**: getConqueredCount() = 0
+
+---
+
+### Method under test: `boolean canAttack(Territory s, Territory t)`
+
+Returns true iff all of: s is owned by the attacker; s.getTroopCount() ≥ 2;
+s and t are adjacent (game.getMap().areAdjacent(s, t)); t is not owned by the attacker.
+
+**s.getTroopCount() (interval, lower bound 2):**
+
+- **TC2: s.getTroopCount() = 1 (below lower bound) → false** ( :x: )
+  - **State of the system**: s owned by attacker, s has 1 troop, s and t adjacent, t owned by enemy
+  - **Expected output**: false
+
+- **TC3: s.getTroopCount() = 2 (lower bound) and all conditions met → true** ( :x: )
+  - **State of the system**: s owned by attacker, s has 2 troops, s and t adjacent, t owned by enemy
+  - **Expected output**: true
+
+**Boolean conditions (each tested independently; all other conditions valid):**
+
+- **TC4: s not owned by attacker → false** ( :x: )
+  - **State of the system**: s.getOwner() returns a different player
+  - **Expected output**: false
+
+- **TC5: s and t not adjacent → false** ( :x: )
+  - **State of the system**: game.getMap().areAdjacent(s, t) returns false
+  - **Expected output**: false
+
+- **TC6: t owned by attacker → false** ( :x: )
+  - **State of the system**: t.getOwner() returns the attacker
+  - **Expected output**: false
+
+---
+
+### Method under test: `void declareAttack(Territory s, Territory t, int n)`
+
+Validates attack parameters. n is the number of attacking dice: interval [1, 3] with additional
+constraint n ≤ s.getTroopCount() − 1 (source must retain at least 1 army after attackers commit).
+
+**n count (interval [1, 3]):**
+
+- **TC7: n = 0 (below lower bound) → IllegalArgumentException** ( :x: )
+  - **State of the system**: valid s, t; n = 0
+  - **Expected output**: IllegalArgumentException thrown
+
+- **TC8: n = 1 (lower bound), s.getTroopCount() = 2 → no exception** ( :x: )
+  - **State of the system**: s owned by attacker, s has 2 troops, s and t adjacent, t owned by enemy
+  - **Expected output**: no exception; ownership and adjacency checks made on mocks
+
+- **TC9: n = 3 (upper bound), s.getTroopCount() = 4 → no exception** ( :x: )
+  - **State of the system**: s owned by attacker, s has 4 troops, s and t adjacent, t owned by enemy
+  - **Expected output**: no exception; ownership and adjacency checks made on mocks
+
+- **TC10: n = 4 (above upper bound) → IllegalArgumentException** ( :x: )
+  - **State of the system**: valid s, t; n = 4
+  - **Expected output**: IllegalArgumentException thrown
+
+**Army constraint (n ≤ s.getTroopCount() − 1):**
+
+- **TC11: n > s.getTroopCount() − 1 (e.g., n = 2, s.getTroopCount() = 2) → IllegalArgumentException** ( :x: )
+  - **State of the system**: n within [1, 3] but s does not have enough armies (needs n + 1)
+  - **Expected output**: IllegalArgumentException thrown
+
+**Territory validation:**
+
+- **TC12: s not owned by attacker → IllegalArgumentException** ( :x: )
+  - **State of the system**: s.getOwner() returns a different player
+  - **Expected output**: IllegalArgumentException thrown
+
+- **TC13: s and t not adjacent → IllegalArgumentException** ( :x: )
+  - **State of the system**: game.getMap().areAdjacent(s, t) returns false
+  - **Expected output**: IllegalArgumentException thrown
+
+- **TC14: t owned by attacker → IllegalArgumentException** ( :x: )
+  - **State of the system**: t.getOwner() returns the attacker
+  - **Expected output**: IllegalArgumentException thrown
+
+---
+
+### Method under test: `void resolveBattle(Territory s, Territory t, int n)`
+
+Precondition: `declareAttack(s, t, n)` passed validation. Rolls n attacker dice and
+min(2, t.getTroopCount()) defender dice via diceRoller, compares them, and applies losses.
+If defenderLosses exhaust t's armies (conquest), conqueredCount is incremented and
+t.removeTroops is NOT called (Territory.removeTroops throws at 0; ownership transferred
+later by moveInTroops). If no conquest, t.removeTroops(defenderLosses) is called normally.
+
+**Defender dice count (min(2, t.getTroopCount()), interval [1, 2]):**
+
+- **TC15: t.getTroopCount() = 1 (lower bound → defender rolls 1 die)** ( :x: )
+  - **State of the system**: t has 1 troop; diceRoller.rollDefender(1) mocked
+  - **Expected output**: diceRoller.rollDefender(1) called; losses applied
+
+- **TC16: t.getTroopCount() = 2 (upper bound → defender rolls 2 dice)** ( :x: )
+  - **State of the system**: t has 2 troops; diceRoller.rollDefender(2) mocked
+  - **Expected output**: diceRoller.rollDefender(2) called; losses applied
+
+**Post-battle conquest boundary (Count with 0 as conquest threshold):**
+
+- **TC17: no conquest — t has armies remaining after battle** ( :x: )
+  - **State of the system**: defenderLosses < t.getTroopCount(); mocked dice produce this outcome
+  - **Expected output**: s.removeTroops(attackerLosses) called; t.removeTroops(defenderLosses)
+    called; conqueredCount remains 0
+
+- **TC18: conquest — defenderLosses exhaust t's armies** ( :x: )
+  - **State of the system**: defenderLosses = t.getTroopCount(); mocked dice produce this outcome
+  - **Expected output**: s.removeTroops(attackerLosses) called; t.removeTroops NOT called;
+    conqueredCount = 1
+
+---
+
+### Method under test: `void moveInTroops(Territory s, Territory t, int n)`
+
+Precondition: t was just conquered via resolveBattle. n is the number of troops to move from s
+into t. n must be in [lastAttackDice, s.getTroopCount() − 1], where lastAttackDice is the dice
+count from the preceding resolveBattle call (stored internally by AttackPhase).
+
+**n count (interval [lastAttackDice, s.getTroopCount() − 1]):**
+
+- **TC19: n < lastAttackDice (below lower bound) → IllegalArgumentException** ( :x: )
+  - **State of the system**: lastAttackDice = 2; n = 1; s has 5 troops
+  - **Expected output**: IllegalArgumentException thrown
+
+- **TC20: n = lastAttackDice (lower bound) — valid** ( :x: )
+  - **State of the system**: lastAttackDice = 2; n = 2; s has 5 troops; t conquered
+  - **Expected output**: t.conquer(attacker, 2) called; s.removeTroops(2) called;
+    old owner's territory list updated; attacker's territory list updated
+
+- **TC21: n = s.getTroopCount() − 1 (upper bound) — valid** ( :x: )
+  - **State of the system**: lastAttackDice = 1; n = s.getTroopCount() − 1; t conquered
+  - **Expected output**: t.conquer(attacker, n) called; s.removeTroops(n) called;
+    territory ownership updated
+
+- **TC22: n = s.getTroopCount() (above upper bound) → IllegalArgumentException** ( :x: )
+  - **State of the system**: n equals s.getTroopCount() (would leave source with 0 armies)
+  - **Expected output**: IllegalArgumentException thrown
+
+---
+
+### Method under test: `void awardCardIfEarned()`
+
+conqueredCount is a Count variable (≥ 0). Exactly 1 card is drawn from game and given to
+attacker iff conqueredCount ≥ 1, regardless of how many territories were conquered.
+
+**conqueredCount (Count, lower bound 0):**
+
+- **TC23: conqueredCount = 0 (no territories conquered) → no card drawn** ( :x: )
+  - **State of the system**: conqueredCount = 0 (no resolveBattle resulted in conquest)
+  - **Expected output**: game.drawCard() not called; attacker.addCard() not called
+
+- **TC24: conqueredCount = 1 (lower bound for card award) → one card drawn** ( :x: )
+  - **State of the system**: conqueredCount = 1 (one conquest this turn); game.drawCard() mocked
+  - **Expected output**: game.drawCard() called exactly once; attacker.addCard(card) called
+
+- **TC25: conqueredCount = 2 (above lower bound) → exactly one card drawn** ( :x: )
+  - **State of the system**: conqueredCount = 2; game.drawCard() mocked
+  - **Expected output**: game.drawCard() called exactly once (not twice)
+
+---
+
+### Method under test: `void endPhase()`
+
+Postcondition: card awarded if any territory was conquered. endPhase delegates to
+awardCardIfEarned; BVA tests verify the observable effects through that delegation.
+
+- **TC26: endPhase with conqueredCount = 0 → no card drawn** ( :x: )
+  - **State of the system**: no conquests this turn
+  - **Expected output**: game.drawCard() not called; attacker.addCard() not called
+
+- **TC27: endPhase with conqueredCount ≥ 1 → card drawn and given to attacker** ( :x: )
+  - **State of the system**: at least one conquest this turn; game.drawCard() mocked
+  - **Expected output**: game.drawCard() called once; attacker.addCard(card) called

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -76,7 +76,7 @@ constraint n ≤ s.getTroopCount() − 1 (source must retain at least 1 army aft
   - **State of the system**: s.getOwner() returns a different player
   - **Expected output**: IllegalArgumentException thrown
 
-- **TC13: s and t not adjacent → IllegalArgumentException** ( :x: )
+- **TC13: s and t not adjacent → IllegalArgumentException** ( :white_check_mark: )
   - **State of the system**: game.getMap().areAdjacent(s, t) returns false
   - **Expected output**: IllegalArgumentException thrown
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -31,7 +31,7 @@ s and t are adjacent (game.getMap().areAdjacent(s, t)); t is not owned by the at
   - **State of the system**: s.getOwner() returns a different player
   - **Expected output**: false
 
-- **TC5: s and t not adjacent → false** ( :x: )
+- **TC5: s and t not adjacent → false** ( :white_check_mark: )
   - **State of the system**: game.getMap().areAdjacent(s, t) returns false
   - **Expected output**: false
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -130,7 +130,7 @@ count from the preceding resolveBattle call (stored internally by AttackPhase).
   - **State of the system**: lastAttackDice = 2; n = 1; s has 5 troops
   - **Expected output**: IllegalArgumentException thrown
 
-- **TC20: n = lastAttackDice (lower bound) — valid** ( :x: )
+- **TC20: n = lastAttackDice (lower bound) — valid** ( :white_check_mark: )
   - **State of the system**: lastAttackDice = 2; n = 2; s has 5 troops; t conquered
   - **Expected output**: t.conquer(attacker, 2) called; s.removeTroops(2) called;
     old owner's territory list updated; attacker's territory list updated

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -48,7 +48,7 @@ constraint n ≤ s.getTroopCount() − 1 (source must retain at least 1 army aft
 
 **n count (interval [1, 3]):**
 
-- **TC7: n = 0 (below lower bound) → IllegalArgumentException** ( :x: )
+- **TC7: n = 0 (below lower bound) → IllegalArgumentException** ( :white_check_mark: )
   - **State of the system**: valid s, t; n = 0
   - **Expected output**: IllegalArgumentException thrown
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -17,7 +17,7 @@ s and t are adjacent (game.getMap().areAdjacent(s, t)); t is not owned by the at
 
 **s.getTroopCount() (interval, lower bound 2):**
 
-- **TC2: s.getTroopCount() = 1 (below lower bound) → false** ( :x: )
+- **TC2: s.getTroopCount() = 1 (below lower bound) → false** ( :white_check_mark: )
   - **State of the system**: s owned by attacker, s has 1 troop, s and t adjacent, t owned by enemy
   - **Expected output**: false
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -153,7 +153,7 @@ attacker iff conqueredCount ≥ 1, regardless of how many territories were conqu
 
 **conqueredCount (Count, lower bound 0):**
 
-- **TC23: conqueredCount = 0 (no territories conquered) → no card drawn** ( :x: )
+- **TC23: conqueredCount = 0 (no territories conquered) → no card drawn** ( :white_check_mark: )
   - **State of the system**: conqueredCount = 0 (no resolveBattle resulted in conquest)
   - **Expected output**: game.drawCard() not called; attacker.addCard() not called
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -111,7 +111,7 @@ later by moveInTroops). If no conquest, t.removeTroops(defenderLosses) is called
   - **Expected output**: s.removeTroops(attackerLosses) called; t.removeTroops(defenderLosses)
     called; conqueredCount remains 0
 
-- **TC18: conquest — defenderLosses exhaust t's armies** ( :x: )
+- **TC18: conquest — defenderLosses exhaust t's armies** ( :white_check_mark: )
   - **State of the system**: defenderLosses = t.getTroopCount(); mocked dice produce this outcome
   - **Expected output**: s.removeTroops(attackerLosses) called; t.removeTroops NOT called;
     conqueredCount = 1

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -52,7 +52,7 @@ constraint n ≤ s.getTroopCount() − 1 (source must retain at least 1 army aft
   - **State of the system**: valid s, t; n = 0
   - **Expected output**: IllegalArgumentException thrown
 
-- **TC8: n = 1 (lower bound), s.getTroopCount() = 2 → no exception** ( :x: )
+- **TC8: n = 1 (lower bound), s.getTroopCount() = 2 → no exception** ( :white_check_mark: )
   - **State of the system**: s owned by attacker, s has 2 troops, s and t adjacent, t owned by enemy
   - **Expected output**: no exception; ownership and adjacency checks made on mocks
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -172,7 +172,7 @@ attacker iff conqueredCount ≥ 1, regardless of how many territories were conqu
 Postcondition: card awarded if any territory was conquered. endPhase delegates to
 awardCardIfEarned; BVA tests verify the observable effects through that delegation.
 
-- **TC26: endPhase with conqueredCount = 0 → no card drawn** ( :x: )
+- **TC26: endPhase with conqueredCount = 0 → no card drawn** ( :white_check_mark: )
   - **State of the system**: no conquests this turn
   - **Expected output**: game.drawCard() not called; attacker.addCard() not called
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -100,7 +100,7 @@ later by moveInTroops). If no conquest, t.removeTroops(defenderLosses) is called
   - **State of the system**: t has 1 troop; diceRoller.rollDefender(1) mocked
   - **Expected output**: diceRoller.rollDefender(1) called; losses applied
 
-- **TC16: t.getTroopCount() = 2 (upper bound → defender rolls 2 dice)** ( :x: )
+- **TC16: t.getTroopCount() = 2 (upper bound → defender rolls 2 dice)** ( :white_check_mark: )
   - **State of the system**: t has 2 troops; diceRoller.rollDefender(2) mocked
   - **Expected output**: diceRoller.rollDefender(2) called; losses applied
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -72,7 +72,7 @@ constraint n ≤ s.getTroopCount() − 1 (source must retain at least 1 army aft
 
 **Territory validation:**
 
-- **TC12: s not owned by attacker → IllegalArgumentException** ( :x: )
+- **TC12: s not owned by attacker → IllegalArgumentException** ( :white_check_mark: )
   - **State of the system**: s.getOwner() returns a different player
   - **Expected output**: IllegalArgumentException thrown
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -21,7 +21,7 @@ s and t are adjacent (game.getMap().areAdjacent(s, t)); t is not owned by the at
   - **State of the system**: s owned by attacker, s has 1 troop, s and t adjacent, t owned by enemy
   - **Expected output**: false
 
-- **TC3: s.getTroopCount() = 2 (lower bound) and all conditions met → true** ( :x: )
+- **TC3: s.getTroopCount() = 2 (lower bound) and all conditions met → true** ( :white_check_mark: )
   - **State of the system**: s owned by attacker, s has 2 troops, s and t adjacent, t owned by enemy
   - **Expected output**: true
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -135,7 +135,7 @@ count from the preceding resolveBattle call (stored internally by AttackPhase).
   - **Expected output**: t.conquer(attacker, 2) called; s.removeTroops(2) called;
     old owner's territory list updated; attacker's territory list updated
 
-- **TC21: n = s.getTroopCount() − 1 (upper bound) — valid** ( :x: )
+- **TC21: n = s.getTroopCount() − 1 (upper bound) — valid** ( :white_check_mark: )
   - **State of the system**: lastAttackDice = 1; n = s.getTroopCount() − 1; t conquered
   - **Expected output**: t.conquer(attacker, n) called; s.removeTroops(n) called;
     territory ownership updated

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -66,7 +66,7 @@ constraint n ≤ s.getTroopCount() − 1 (source must retain at least 1 army aft
 
 **Army constraint (n ≤ s.getTroopCount() − 1):**
 
-- **TC11: n > s.getTroopCount() − 1 (e.g., n = 2, s.getTroopCount() = 2) → IllegalArgumentException** ( :x: )
+- **TC11: n > s.getTroopCount() − 1 (e.g., n = 2, s.getTroopCount() = 2) → IllegalArgumentException** ( :white_check_mark: )
   - **State of the system**: n within [1, 3] but s does not have enough armies (needs n + 1)
   - **Expected output**: IllegalArgumentException thrown
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -157,7 +157,7 @@ attacker iff conqueredCount ≥ 1, regardless of how many territories were conqu
   - **State of the system**: conqueredCount = 0 (no resolveBattle resulted in conquest)
   - **Expected output**: game.drawCard() not called; attacker.addCard() not called
 
-- **TC24: conqueredCount = 1 (lower bound for card award) → one card drawn** ( :x: )
+- **TC24: conqueredCount = 1 (lower bound for card award) → one card drawn** ( :white_check_mark: )
   - **State of the system**: conqueredCount = 1 (one conquest this turn); game.drawCard() mocked
   - **Expected output**: game.drawCard() called exactly once; attacker.addCard(card) called
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -4,7 +4,7 @@
 
 Precondition: all arguments non-null. `conqueredCount` initializes to 0.
 
-- **TC1: valid arguments — conqueredCount initialized to 0** ( :x: )
+- **TC1: valid arguments — conqueredCount initialized to 0** ( :white_check_mark: )
   - **State of the system**: attacker, diceRoller, game provided
   - **Expected output**: getConqueredCount() = 0
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -35,7 +35,7 @@ s and t are adjacent (game.getMap().areAdjacent(s, t)); t is not owned by the at
   - **State of the system**: game.getMap().areAdjacent(s, t) returns false
   - **Expected output**: false
 
-- **TC6: t owned by attacker → false** ( :x: )
+- **TC6: t owned by attacker → false** ( :white_check_mark: )
   - **State of the system**: t.getOwner() returns the attacker
   - **Expected output**: false
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -140,7 +140,7 @@ count from the preceding resolveBattle call (stored internally by AttackPhase).
   - **Expected output**: t.conquer(attacker, n) called; s.removeTroops(n) called;
     territory ownership updated
 
-- **TC22: n = s.getTroopCount() (above upper bound) → IllegalArgumentException** ( :x: )
+- **TC22: n = s.getTroopCount() (above upper bound) → IllegalArgumentException** ( :white_check_mark: )
   - **State of the system**: n equals s.getTroopCount() (would leave source with 0 armies)
   - **Expected output**: IllegalArgumentException thrown
 

--- a/docs/bva/AttackPhase.md
+++ b/docs/bva/AttackPhase.md
@@ -27,7 +27,7 @@ s and t are adjacent (game.getMap().areAdjacent(s, t)); t is not owned by the at
 
 **Boolean conditions (each tested independently; all other conditions valid):**
 
-- **TC4: s not owned by attacker → false** ( :x: )
+- **TC4: s not owned by attacker → false** ( :white_check_mark: )
   - **State of the system**: s.getOwner() returns a different player
   - **Expected output**: false
 

--- a/docs/bva/Game.md
+++ b/docs/bva/Game.md
@@ -152,7 +152,7 @@ interval [0, players.size() − 1]. `advanceToNextPlayer()` increments the index
   - **State of the system**: Game constructed with 2 players; currentPlayerIndex set to 0
   - **Expected output**: currentPlayerIndex = 1
 
-- **TC28: 2 players, currentPlayerIndex = 1 (upper bound, last player — wraps to 0)** ( :x: )
+- **TC28: 2 players, currentPlayerIndex = 1 (upper bound, last player — wraps to 0)** ( :white_check_mark: )
   - **State of the system**: Game constructed with 2 players; currentPlayerIndex set to 1
   - **Expected output**: currentPlayerIndex = 0
 

--- a/docs/bva/Game.md
+++ b/docs/bva/Game.md
@@ -170,7 +170,7 @@ conquered at least one territory this turn.
 
 **`deck.size()` (Count, size ≥ 0):**
 
-- **TC30: deck is empty (size = 0, below lower bound)** ( :x: )
+- **TC30: deck is empty (size = 0, below lower bound)** ( :white_check_mark: )
   - **State of the system**: Game constructed with an empty deck
   - **Expected output**: IllegalStateException thrown
 

--- a/docs/bva/Game.md
+++ b/docs/bva/Game.md
@@ -137,3 +137,47 @@ Precondition: Game constructed with 2–6 players, a valid map, and a deck.
 - **TC26: 2 players, result = 1 (upper bound of resulting index)** ( :white_check_mark: )
   - **State of the system**: Game constructed with 2 players; random returns 1 for chooseFirstPlayer call
   - **Expected output**: currentPlayerIndex = 1
+
+---
+
+### Method under test: `void advanceToNextPlayer()`
+
+Precondition: `currentPlayerIndex` has been set (e.g. by `chooseFirstPlayer()`). The index is an
+interval [0, players.size() − 1]. `advanceToNextPlayer()` increments the index with wrap-around:
+`(currentPlayerIndex + 1) % players.size()`.
+
+**`currentPlayerIndex` (interval [0, players.size() − 1]):**
+
+- **TC27: 2 players, currentPlayerIndex = 0 (lower bound, not last player)** ( :x: )
+  - **State of the system**: Game constructed with 2 players; currentPlayerIndex set to 0
+  - **Expected output**: currentPlayerIndex = 1
+
+- **TC28: 2 players, currentPlayerIndex = 1 (upper bound, last player — wraps to 0)** ( :x: )
+  - **State of the system**: Game constructed with 2 players; currentPlayerIndex set to 1
+  - **Expected output**: currentPlayerIndex = 0
+
+- **TC29: 3 players, currentPlayerIndex = 1 (interior, one below last — no wrap)** ( :x: )
+  - **State of the system**: Game constructed with 3 players; currentPlayerIndex set to 1
+  - **Expected output**: currentPlayerIndex = 2
+
+---
+
+### Method under test: `RiskCard drawCard()`
+
+Precondition: Game constructed. `deck` is a Count variable (size ≥ 0). `drawCard()` removes and
+returns the first card from the deck. Called by `AttackPhase.awardCardIfEarned()` when the player
+conquered at least one territory this turn.
+
+**`deck.size()` (Count, size ≥ 0):**
+
+- **TC30: deck is empty (size = 0, below lower bound)** ( :x: )
+  - **State of the system**: Game constructed with an empty deck
+  - **Expected output**: IllegalStateException thrown
+
+- **TC31: deck has 1 card (lower bound, valid)** ( :x: )
+  - **State of the system**: Game constructed with a deck of 1 card
+  - **Expected output**: that card is returned; deck is now empty (size = 0)
+
+- **TC32: deck has 2 cards (one above lower bound)** ( :x: )
+  - **State of the system**: Game constructed with a deck of 2 cards
+  - **Expected output**: first card is returned; deck now has 1 card remaining

--- a/docs/bva/Game.md
+++ b/docs/bva/Game.md
@@ -156,7 +156,7 @@ interval [0, players.size() − 1]. `advanceToNextPlayer()` increments the index
   - **State of the system**: Game constructed with 2 players; currentPlayerIndex set to 1
   - **Expected output**: currentPlayerIndex = 0
 
-- **TC29: 3 players, currentPlayerIndex = 1 (interior, one below last — no wrap)** ( :x: )
+- **TC29: 3 players, currentPlayerIndex = 1 (interior, one below last — no wrap)** ( :white_check_mark: )
   - **State of the system**: Game constructed with 3 players; currentPlayerIndex set to 1
   - **Expected output**: currentPlayerIndex = 2
 

--- a/docs/bva/Game.md
+++ b/docs/bva/Game.md
@@ -174,7 +174,7 @@ conquered at least one territory this turn.
   - **State of the system**: Game constructed with an empty deck
   - **Expected output**: IllegalStateException thrown
 
-- **TC31: deck has 1 card (lower bound, valid)** ( :x: )
+- **TC31: deck has 1 card (lower bound, valid)** ( :white_check_mark: )
   - **State of the system**: Game constructed with a deck of 1 card
   - **Expected output**: that card is returned; deck is now empty (size = 0)
 

--- a/docs/bva/Game.md
+++ b/docs/bva/Game.md
@@ -148,7 +148,7 @@ interval [0, players.size() − 1]. `advanceToNextPlayer()` increments the index
 
 **`currentPlayerIndex` (interval [0, players.size() − 1]):**
 
-- **TC27: 2 players, currentPlayerIndex = 0 (lower bound, not last player)** ( :x: )
+- **TC27: 2 players, currentPlayerIndex = 0 (lower bound, not last player)** ( :white_check_mark: )
   - **State of the system**: Game constructed with 2 players; currentPlayerIndex set to 0
   - **Expected output**: currentPlayerIndex = 1
 

--- a/docs/bva/Game.md
+++ b/docs/bva/Game.md
@@ -178,6 +178,6 @@ conquered at least one territory this turn.
   - **State of the system**: Game constructed with a deck of 1 card
   - **Expected output**: that card is returned; deck is now empty (size = 0)
 
-- **TC32: deck has 2 cards (one above lower bound)** ( :x: )
+- **TC32: deck has 2 cards (one above lower bound)** ( :white_check_mark: )
   - **State of the system**: Game constructed with a deck of 2 cards
   - **Expected output**: first card is returned; deck now has 1 card remaining

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -74,6 +74,9 @@ public class AttackPhase {
     }
   }
 
+  public void awardCardIfEarned() {
+  }
+
   public boolean canAttack(Territory s, Territory t) {
     if (!s.getOwner().equals(attacker)) {
       return false;

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -15,4 +15,11 @@ public class AttackPhase {
   public int getConqueredCount() {
     return conqueredCount;
   }
+
+  public boolean canAttack(Territory s, Territory t) {
+    if (!s.getOwner().equals(attacker)) {
+      return false;
+    }
+    return s.getTroopCount() >= 2;
+  }
 }

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -12,6 +12,7 @@ public class AttackPhase {
   private final DiceRoller diceRoller;
   private final Game game;
   private int conqueredCount = 0;
+  private int lastAttackDice = 0;
 
   public AttackPhase(Player attacker, DiceRoller diceRoller, Game game) {
     this.attacker = attacker;
@@ -41,7 +42,18 @@ public class AttackPhase {
     }
   }
 
+  public void moveInTroops(Territory s, Territory t, int n) {
+    if (n < lastAttackDice) {
+      throw new IllegalArgumentException(
+          "Must move at least as many armies as attacking dice rolled.");
+    }
+    if (n >= s.getTroopCount()) {
+      throw new IllegalArgumentException("Source must retain at least 1 army.");
+    }
+  }
+
   public void resolveBattle(Territory s, Territory t, int n) {
+    lastAttackDice = n;
     int defenderTroops = t.getTroopCount();
     int defenderDice = Math.min(MAX_DEFENDER_DICE, defenderTroops);
     List<Integer> attackerRoll = diceRoller.rollAttacker(n);

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -24,6 +24,18 @@ public class AttackPhase {
     if (n < MIN_ATTACK_DICE || n > MAX_ATTACK_DICE) {
       throw new IllegalArgumentException("Attacker must roll between 1 and 3 dice.");
     }
+    if (!s.getOwner().equals(attacker)) {
+      throw new IllegalArgumentException("Source territory must be owned by the attacker.");
+    }
+    if (t.getOwner().equals(attacker)) {
+      throw new IllegalArgumentException("Target territory must not be owned by the attacker.");
+    }
+    if (s.getTroopCount() <= n) {
+      throw new IllegalArgumentException("Source must have more armies than dice rolled.");
+    }
+    if (!game.getMap().areAdjacent(s, t)) {
+      throw new IllegalArgumentException("Source and target territories must be adjacent.");
+    }
   }
 
   public boolean canAttack(Territory s, Territory t) {

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -1,0 +1,18 @@
+package domain;
+
+public class AttackPhase {
+  private final Player attacker;
+  private final DiceRoller diceRoller;
+  private final Game game;
+  private int conqueredCount = 0;
+
+  public AttackPhase(Player attacker, DiceRoller diceRoller, Game game) {
+    this.attacker = attacker;
+    this.diceRoller = diceRoller;
+    this.game = game;
+  }
+
+  public int getConqueredCount() {
+    return conqueredCount;
+  }
+}

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -1,8 +1,11 @@
 package domain;
 
+import java.util.List;
+
 public class AttackPhase {
   private static final int MIN_ATTACK_DICE = 1;
   private static final int MAX_ATTACK_DICE = 3;
+  private static final int MAX_DEFENDER_DICE = 2;
   private static final int MIN_TROOPS_TO_ATTACK = 2;
 
   private final Player attacker;
@@ -35,6 +38,22 @@ public class AttackPhase {
     }
     if (!game.getMap().areAdjacent(s, t)) {
       throw new IllegalArgumentException("Source and target territories must be adjacent.");
+    }
+  }
+
+  public void resolveBattle(Territory s, Territory t, int n) {
+    int defenderTroops = t.getTroopCount();
+    int defenderDice = Math.min(MAX_DEFENDER_DICE, defenderTroops);
+    List<Integer> attackerRoll = diceRoller.rollAttacker(n);
+    List<Integer> defenderRoll = diceRoller.rollDefender(defenderDice);
+    BattleResult result = diceRoller.compare(attackerRoll, defenderRoll);
+    if (result.getAttackerLosses() > 0) {
+      s.removeTroops(result.getAttackerLosses());
+    }
+    if (result.getDefenderLosses() >= defenderTroops) {
+      conqueredCount++;
+    } else if (result.getDefenderLosses() > 0) {
+      t.removeTroops(result.getDefenderLosses());
     }
   }
 

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -1,6 +1,10 @@
 package domain;
 
 public class AttackPhase {
+  private static final int MIN_ATTACK_DICE = 1;
+  private static final int MAX_ATTACK_DICE = 3;
+  private static final int MIN_TROOPS_TO_ATTACK = 2;
+
   private final Player attacker;
   private final DiceRoller diceRoller;
   private final Game game;
@@ -16,11 +20,17 @@ public class AttackPhase {
     return conqueredCount;
   }
 
+  public void declareAttack(Territory s, Territory t, int n) {
+    if (n < MIN_ATTACK_DICE || n > MAX_ATTACK_DICE) {
+      throw new IllegalArgumentException("Attacker must roll between 1 and 3 dice.");
+    }
+  }
+
   public boolean canAttack(Territory s, Territory t) {
     if (!s.getOwner().equals(attacker)) {
       return false;
     }
-    if (s.getTroopCount() < 2) {
+    if (s.getTroopCount() < MIN_TROOPS_TO_ATTACK) {
       return false;
     }
     if (!game.getMap().areAdjacent(s, t)) {

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -50,6 +50,11 @@ public class AttackPhase {
     if (n >= s.getTroopCount()) {
       throw new IllegalArgumentException("Source must retain at least 1 army.");
     }
+    Player previousOwner = t.getOwner();
+    previousOwner.removeTerritory(t);
+    attacker.addTerritory(t);
+    t.conquer(attacker, n);
+    s.removeTroops(n);
   }
 
   public void resolveBattle(Territory s, Territory t, int n) {

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -74,6 +74,10 @@ public class AttackPhase {
     }
   }
 
+  public void endPhase() {
+    awardCardIfEarned();
+  }
+
   public void awardCardIfEarned() {
     if (conqueredCount > 0) {
       attacker.addCard(game.drawCard());

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -75,6 +75,9 @@ public class AttackPhase {
   }
 
   public void awardCardIfEarned() {
+    if (conqueredCount > 0) {
+      attacker.addCard(game.drawCard());
+    }
   }
 
   public boolean canAttack(Territory s, Territory t) {

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -20,6 +20,12 @@ public class AttackPhase {
     if (!s.getOwner().equals(attacker)) {
       return false;
     }
-    return s.getTroopCount() >= 2;
+    if (s.getTroopCount() < 2) {
+      return false;
+    }
+    if (!game.getMap().areAdjacent(s, t)) {
+      return false;
+    }
+    return !t.getOwner().equals(attacker);
   }
 }

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -13,6 +13,7 @@ public class AttackPhase {
   private final Game game;
   private int conqueredCount = 0;
   private int lastAttackDice = 0;
+  private boolean ended = false;
 
   public AttackPhase(Player attacker, DiceRoller diceRoller, Game game) {
     this.attacker = attacker;
@@ -74,8 +75,13 @@ public class AttackPhase {
     }
   }
 
+  public boolean isEnded() {
+    return ended;
+  }
+
   public void endPhase() {
     awardCardIfEarned();
+    ended = true;
   }
 
   public void awardCardIfEarned() {

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -100,4 +100,8 @@ public class Game {
   public int getCurrentPlayerIndex() {
     return currentPlayerIndex;
   }
+
+  public void advanceToNextPlayer() {
+    currentPlayerIndex = (currentPlayerIndex + 1) % players.size();
+  }
 }

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -104,4 +104,11 @@ public class Game {
   public void advanceToNextPlayer() {
     currentPlayerIndex = (currentPlayerIndex + 1) % players.size();
   }
+
+  public RiskCard drawCard() {
+    if (deck.isEmpty()) {
+      throw new IllegalStateException("Cannot draw from an empty deck.");
+    }
+    return deck.remove(0);
+  }
 }

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -74,7 +74,7 @@ public class Game {
   }
 
   public void shuffleDeck() {
-    Collections.shuffle(deck);
+    Collections.shuffle(deck, random);
   }
 
   public void chooseFirstPlayer() {

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -108,10 +108,6 @@ public class Game {
     return currentPlayerIndex;
   }
 
-  public void advanceToNextPlayer() {
-    currentPlayerIndex = (currentPlayerIndex + 1) % players.size();
-  }
-
   public RiskCard drawCard() {
     if (deck.isEmpty()) {
       throw new IllegalStateException("Cannot draw from an empty deck.");

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -114,7 +114,7 @@ public class Turn {
   }
 
   protected AttackPhase createAttackPhase(Player p, Game g, Random r) {
-    return new AttackPhase(p, g, r);
+    return new AttackPhase(p, new DiceRoller(r), g);
   }
 
   protected FortificationPhase createFortificationPhase(Player p, Game g) {

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -81,4 +81,25 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, enemy, diceRoller, game, s, t);
   }
+
+  @Test
+  public void canAttack_territoriesNotAdjacent_returnsFalse() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    GameMap map = EasyMock.createMock(GameMap.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    EasyMock.expect(s.getOwner()).andReturn(attacker);
+    EasyMock.expect(s.getTroopCount()).andReturn(2);
+    EasyMock.expect(game.getMap()).andReturn(map);
+    EasyMock.expect(map.areAdjacent(s, t)).andReturn(false);
+    EasyMock.replay(attacker, diceRoller, game, map, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    assertFalse(phase.canAttack(s, t));
+
+    EasyMock.verify(attacker, diceRoller, game, map, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -379,4 +379,29 @@ public class AttackPhaseTests {
     assertEquals(1, phase.getConqueredCount());
     EasyMock.verify(attacker, diceRoller, game, s, t);
   }
+
+  @Test
+  public void moveInTroops_nBelowLastAttackDice_throwsIllegalArgumentException() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    List<Integer> attackDice = List.of(6, 5);
+    List<Integer> defendDice = List.of(1);
+    EasyMock.expect(diceRoller.rollAttacker(2)).andReturn(attackDice);
+    EasyMock.expect(t.getTroopCount()).andReturn(1);
+    EasyMock.expect(diceRoller.rollDefender(1)).andReturn(defendDice);
+    EasyMock.expect(diceRoller.compare(attackDice, defendDice))
+        .andReturn(new BattleResult(List.of(6, 5), List.of(1), false));
+    EasyMock.replay(attacker, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.resolveBattle(s, t, 2);
+    assertThrows(IllegalArgumentException.class,
+        () -> phase.moveInTroops(s, t, 1));
+
+    EasyMock.verify(attacker, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -507,6 +507,19 @@ public class AttackPhaseTests {
   }
 
   @Test
+  public void endPhase_noConquest_noCardDrawn() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    EasyMock.replay(attacker, diceRoller, game);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.endPhase();
+
+    EasyMock.verify(attacker, diceRoller, game);
+  }
+
+  @Test
   public void awardCardIfEarned_twoConquests_drawsExactlyOneCard() {
     Player attacker = EasyMock.createMock(Player.class);
     Player enemy = EasyMock.createMock(Player.class);

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -330,4 +330,29 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, diceRoller, game, s, t);
   }
+
+  @Test
+  public void resolveBattle_noConquest_lossesAppliedAndConqueredCountUnchanged() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    List<Integer> attackDice = List.of(5);
+    List<Integer> defendDice = List.of(3, 2);
+    EasyMock.expect(diceRoller.rollAttacker(1)).andReturn(attackDice);
+    EasyMock.expect(t.getTroopCount()).andReturn(3);
+    EasyMock.expect(diceRoller.rollDefender(2)).andReturn(defendDice);
+    EasyMock.expect(diceRoller.compare(attackDice, defendDice))
+        .andReturn(new BattleResult(List.of(5), List.of(3, 2), false));
+    t.removeTroops(1);
+    EasyMock.replay(attacker, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.resolveBattle(s, t, 1);
+
+    assertEquals(0, phase.getConqueredCount());
+    EasyMock.verify(attacker, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -492,4 +492,17 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, diceRoller, game, s, t);
   }
+
+  @Test
+  public void awardCardIfEarned_noConquest_noCardDrawn() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    EasyMock.replay(attacker, diceRoller, game);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.awardCardIfEarned();
+
+    EasyMock.verify(attacker, diceRoller, game);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -435,4 +435,35 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, enemy, diceRoller, game, s, t);
   }
+
+  @Test
+  public void moveInTroops_nEqualsSourceTroopCountMinusOne_transfersOwnershipAndTroops() {
+    Player attacker = EasyMock.createMock(Player.class);
+    Player enemy = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    List<Integer> attackDice = List.of(6);
+    List<Integer> defendDice = List.of(1);
+    EasyMock.expect(diceRoller.rollAttacker(1)).andReturn(attackDice);
+    EasyMock.expect(t.getTroopCount()).andReturn(1);
+    EasyMock.expect(diceRoller.rollDefender(1)).andReturn(defendDice);
+    EasyMock.expect(diceRoller.compare(attackDice, defendDice))
+        .andReturn(new BattleResult(List.of(6), List.of(1), false));
+    EasyMock.expect(s.getTroopCount()).andReturn(5);
+    EasyMock.expect(t.getOwner()).andReturn(enemy);
+    enemy.removeTerritory(t);
+    attacker.addTerritory(t);
+    t.conquer(attacker, 4);
+    s.removeTroops(4);
+    EasyMock.replay(attacker, enemy, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.resolveBattle(s, t, 1);
+    phase.moveInTroops(s, t, 4);
+
+    EasyMock.verify(attacker, enemy, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -262,4 +262,23 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, enemy, diceRoller, game, map, s, t);
   }
+
+  @Test
+  public void declareAttack_targetOwnedByAttacker_throwsIllegalArgumentException() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    EasyMock.expect(s.getOwner()).andReturn(attacker);
+    EasyMock.expect(t.getOwner()).andReturn(attacker);
+    EasyMock.replay(attacker, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    assertThrows(IllegalArgumentException.class,
+        () -> phase.declareAttack(s, t, 1));
+
+    EasyMock.verify(attacker, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -404,4 +404,35 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, diceRoller, game, s, t);
   }
+
+  @Test
+  public void moveInTroops_nEqualsLastAttackDice_transfersOwnershipAndTroops() {
+    Player attacker = EasyMock.createMock(Player.class);
+    Player enemy = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    List<Integer> attackDice = List.of(6, 5);
+    List<Integer> defendDice = List.of(1);
+    EasyMock.expect(diceRoller.rollAttacker(2)).andReturn(attackDice);
+    EasyMock.expect(t.getTroopCount()).andReturn(1);
+    EasyMock.expect(diceRoller.rollDefender(1)).andReturn(defendDice);
+    EasyMock.expect(diceRoller.compare(attackDice, defendDice))
+        .andReturn(new BattleResult(List.of(6, 5), List.of(1), false));
+    EasyMock.expect(s.getTroopCount()).andReturn(5);
+    EasyMock.expect(t.getOwner()).andReturn(enemy);
+    enemy.removeTerritory(t);
+    attacker.addTerritory(t);
+    t.conquer(attacker, 2);
+    s.removeTroops(2);
+    EasyMock.replay(attacker, enemy, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.resolveBattle(s, t, 2);
+    phase.moveInTroops(s, t, 2);
+
+    EasyMock.verify(attacker, enemy, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -198,4 +198,25 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, diceRoller, game);
   }
+
+  @Test
+  public void declareAttack_nExceedsTroopCountMinusOne_throwsIllegalArgumentException() {
+    Player attacker = EasyMock.createMock(Player.class);
+    Player enemy = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    EasyMock.expect(s.getOwner()).andReturn(attacker);
+    EasyMock.expect(t.getOwner()).andReturn(enemy);
+    EasyMock.expect(s.getTroopCount()).andReturn(2);
+    EasyMock.replay(attacker, enemy, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    assertThrows(IllegalArgumentException.class,
+        () -> phase.declareAttack(s, t, 2));
+
+    EasyMock.verify(attacker, enemy, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -466,4 +466,30 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, enemy, diceRoller, game, s, t);
   }
+
+  @Test
+  public void moveInTroops_nEqualsTroopCount_throwsIllegalArgumentException() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    List<Integer> attackDice = List.of(6);
+    List<Integer> defendDice = List.of(1);
+    EasyMock.expect(diceRoller.rollAttacker(1)).andReturn(attackDice);
+    EasyMock.expect(t.getTroopCount()).andReturn(1);
+    EasyMock.expect(diceRoller.rollDefender(1)).andReturn(defendDice);
+    EasyMock.expect(diceRoller.compare(attackDice, defendDice))
+        .andReturn(new BattleResult(List.of(6), List.of(1), false));
+    EasyMock.expect(s.getTroopCount()).andReturn(3);
+    EasyMock.replay(attacker, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.resolveBattle(s, t, 1);
+    assertThrows(IllegalArgumentException.class,
+        () -> phase.moveInTroops(s, t, 3));
+
+    EasyMock.verify(attacker, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -507,6 +507,33 @@ public class AttackPhaseTests {
   }
 
   @Test
+  public void endPhase_oneConquest_drawsCardAndAddsToAttacker() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    RiskCard card = EasyMock.createMock(RiskCard.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    List<Integer> attackDice = List.of(6);
+    List<Integer> defendDice = List.of(1);
+    EasyMock.expect(diceRoller.rollAttacker(1)).andReturn(attackDice);
+    EasyMock.expect(t.getTroopCount()).andReturn(1);
+    EasyMock.expect(diceRoller.rollDefender(1)).andReturn(defendDice);
+    EasyMock.expect(diceRoller.compare(attackDice, defendDice))
+        .andReturn(new BattleResult(List.of(6), List.of(1), false));
+    EasyMock.expect(game.drawCard()).andReturn(card);
+    attacker.addCard(card);
+    EasyMock.replay(attacker, diceRoller, game, card, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.resolveBattle(s, t, 1);
+    phase.endPhase();
+
+    EasyMock.verify(attacker, diceRoller, game, card, s, t);
+  }
+
+  @Test
   public void endPhase_noConquest_noCardDrawn() {
     Player attacker = EasyMock.createMock(Player.class);
     DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -1,0 +1,25 @@
+package domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+public class AttackPhaseTests {
+
+  @Test
+  public void constructor_validArguments_conqueredCountInitializedToZero() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    EasyMock.replay(attacker, diceRoller, game);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+
+    assertEquals(0, phase.getConqueredCount());
+    EasyMock.verify(attacker, diceRoller, game);
+  }
+}

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -184,4 +184,18 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, enemy, diceRoller, game, map, s, t);
   }
+
+  @Test
+  public void declareAttack_nEqualsFour_throwsIllegalArgumentException() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    EasyMock.replay(attacker, diceRoller, game);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    assertThrows(IllegalArgumentException.class,
+        () -> phase.declareAttack(null, null, 4));
+
+    EasyMock.verify(attacker, diceRoller, game);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -219,4 +219,23 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, enemy, diceRoller, game, s, t);
   }
+
+  @Test
+  public void declareAttack_sourceNotOwnedByAttacker_throwsIllegalArgumentException() {
+    Player attacker = EasyMock.createMock(Player.class);
+    Player enemy = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    EasyMock.expect(s.getOwner()).andReturn(enemy);
+    EasyMock.replay(attacker, enemy, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    assertThrows(IllegalArgumentException.class,
+        () -> phase.declareAttack(s, t, 1));
+
+    EasyMock.verify(attacker, enemy, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -124,4 +124,18 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, diceRoller, game, map, s, t);
   }
+
+  @Test
+  public void declareAttack_nEqualsZero_throwsIllegalArgumentException() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    EasyMock.replay(attacker, diceRoller, game);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    assertThrows(IllegalArgumentException.class,
+        () -> phase.declareAttack(null, null, 0));
+
+    EasyMock.verify(attacker, diceRoller, game);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -63,4 +63,22 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, enemy, diceRoller, game, map, s, t);
   }
+
+  @Test
+  public void canAttack_sourceNotOwnedByAttacker_returnsFalse() {
+    Player attacker = EasyMock.createMock(Player.class);
+    Player enemy = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    EasyMock.expect(s.getOwner()).andReturn(enemy);
+    EasyMock.replay(attacker, enemy, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    assertFalse(phase.canAttack(s, t));
+
+    EasyMock.verify(attacker, enemy, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 
@@ -278,6 +279,30 @@ public class AttackPhaseTests {
     AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
     assertThrows(IllegalArgumentException.class,
         () -> phase.declareAttack(s, t, 1));
+
+    EasyMock.verify(attacker, diceRoller, game, s, t);
+  }
+
+  @Test
+  public void resolveBattle_defenderHasOneTroop_rollsOneDie() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    List<Integer> attackDice = List.of(3);
+    List<Integer> defendDice = List.of(4);
+    EasyMock.expect(diceRoller.rollAttacker(1)).andReturn(attackDice);
+    EasyMock.expect(t.getTroopCount()).andReturn(1);
+    EasyMock.expect(diceRoller.rollDefender(1)).andReturn(defendDice);
+    EasyMock.expect(diceRoller.compare(attackDice, defendDice))
+        .andReturn(new BattleResult(List.of(3), List.of(4), false));
+    s.removeTroops(1);
+    EasyMock.replay(attacker, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.resolveBattle(s, t, 1);
 
     EasyMock.verify(attacker, diceRoller, game, s, t);
   }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -161,4 +161,27 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, enemy, diceRoller, game, map, s, t);
   }
+
+  @Test
+  public void declareAttack_nEqualsThree_sourceTroopCountFour_noException() {
+    Player attacker = EasyMock.createMock(Player.class);
+    Player enemy = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    GameMap map = EasyMock.createMock(GameMap.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    EasyMock.expect(s.getOwner()).andReturn(attacker);
+    EasyMock.expect(t.getOwner()).andReturn(enemy);
+    EasyMock.expect(s.getTroopCount()).andReturn(4);
+    EasyMock.expect(game.getMap()).andReturn(map);
+    EasyMock.expect(map.areAdjacent(s, t)).andReturn(true);
+    EasyMock.replay(attacker, enemy, diceRoller, game, map, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.declareAttack(s, t, 3);
+
+    EasyMock.verify(attacker, enemy, diceRoller, game, map, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -505,4 +505,31 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, diceRoller, game);
   }
+
+  @Test
+  public void awardCardIfEarned_oneConquest_drawsOneCardAndAddsToAttacker() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    RiskCard card = EasyMock.createMock(RiskCard.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    List<Integer> attackDice = List.of(6);
+    List<Integer> defendDice = List.of(1);
+    EasyMock.expect(diceRoller.rollAttacker(1)).andReturn(attackDice);
+    EasyMock.expect(t.getTroopCount()).andReturn(1);
+    EasyMock.expect(diceRoller.rollDefender(1)).andReturn(defendDice);
+    EasyMock.expect(diceRoller.compare(attackDice, defendDice))
+        .andReturn(new BattleResult(List.of(6), List.of(1), false));
+    EasyMock.expect(game.drawCard()).andReturn(card);
+    attacker.addCard(card);
+    EasyMock.replay(attacker, diceRoller, game, card, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.resolveBattle(s, t, 1);
+    phase.awardCardIfEarned();
+
+    EasyMock.verify(attacker, diceRoller, game, card, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -22,4 +22,22 @@ public class AttackPhaseTests {
     assertEquals(0, phase.getConqueredCount());
     EasyMock.verify(attacker, diceRoller, game);
   }
+
+  @Test
+  public void canAttack_sourceTroopCountOne_returnsFalse() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    EasyMock.expect(s.getOwner()).andReturn(attacker);
+    EasyMock.expect(s.getTroopCount()).andReturn(1);
+    EasyMock.replay(attacker, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    assertFalse(phase.canAttack(s, t));
+
+    EasyMock.verify(attacker, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -40,4 +40,27 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, diceRoller, game, s, t);
   }
+
+  @Test
+  public void canAttack_allConditionsValid_returnsTrue() {
+    Player attacker = EasyMock.createMock(Player.class);
+    Player enemy = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    GameMap map = EasyMock.createMock(GameMap.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    EasyMock.expect(s.getOwner()).andReturn(attacker);
+    EasyMock.expect(s.getTroopCount()).andReturn(2);
+    EasyMock.expect(game.getMap()).andReturn(map);
+    EasyMock.expect(map.areAdjacent(s, t)).andReturn(true);
+    EasyMock.expect(t.getOwner()).andReturn(enemy);
+    EasyMock.replay(attacker, enemy, diceRoller, game, map, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    assertTrue(phase.canAttack(s, t));
+
+    EasyMock.verify(attacker, enemy, diceRoller, game, map, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -306,4 +306,28 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, diceRoller, game, s, t);
   }
+
+  @Test
+  public void resolveBattle_defenderHasTwoTroops_rollsTwoDice() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    List<Integer> attackDice = List.of(3);
+    List<Integer> defendDice = List.of(5, 4);
+    EasyMock.expect(diceRoller.rollAttacker(1)).andReturn(attackDice);
+    EasyMock.expect(t.getTroopCount()).andReturn(2);
+    EasyMock.expect(diceRoller.rollDefender(2)).andReturn(defendDice);
+    EasyMock.expect(diceRoller.compare(attackDice, defendDice))
+        .andReturn(new BattleResult(List.of(3), List.of(5, 4), false));
+    s.removeTroops(1);
+    EasyMock.replay(attacker, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.resolveBattle(s, t, 1);
+
+    EasyMock.verify(attacker, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -138,4 +138,27 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, diceRoller, game);
   }
+
+  @Test
+  public void declareAttack_nEqualsOne_sourceTroopCountTwo_noException() {
+    Player attacker = EasyMock.createMock(Player.class);
+    Player enemy = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    GameMap map = EasyMock.createMock(GameMap.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    EasyMock.expect(s.getOwner()).andReturn(attacker);
+    EasyMock.expect(t.getOwner()).andReturn(enemy);
+    EasyMock.expect(s.getTroopCount()).andReturn(2);
+    EasyMock.expect(game.getMap()).andReturn(map);
+    EasyMock.expect(map.areAdjacent(s, t)).andReturn(true);
+    EasyMock.replay(attacker, enemy, diceRoller, game, map, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.declareAttack(s, t, 1);
+
+    EasyMock.verify(attacker, enemy, diceRoller, game, map, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -507,6 +507,43 @@ public class AttackPhaseTests {
   }
 
   @Test
+  public void awardCardIfEarned_twoConquests_drawsExactlyOneCard() {
+    Player attacker = EasyMock.createMock(Player.class);
+    Player enemy = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    RiskCard card = EasyMock.createMock(RiskCard.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t1 = EasyMock.createMock(Territory.class);
+    Territory t2 = EasyMock.createMock(Territory.class);
+
+    List<Integer> attackDice1 = List.of(6);
+    List<Integer> defendDice1 = List.of(1);
+    List<Integer> attackDice2 = List.of(5);
+    List<Integer> defendDice2 = List.of(2);
+    EasyMock.expect(diceRoller.rollAttacker(1)).andReturn(attackDice1);
+    EasyMock.expect(t1.getTroopCount()).andReturn(1);
+    EasyMock.expect(diceRoller.rollDefender(1)).andReturn(defendDice1);
+    EasyMock.expect(diceRoller.compare(attackDice1, defendDice1))
+        .andReturn(new BattleResult(List.of(6), List.of(1), false));
+    EasyMock.expect(diceRoller.rollAttacker(1)).andReturn(attackDice2);
+    EasyMock.expect(t2.getTroopCount()).andReturn(1);
+    EasyMock.expect(diceRoller.rollDefender(1)).andReturn(defendDice2);
+    EasyMock.expect(diceRoller.compare(attackDice2, defendDice2))
+        .andReturn(new BattleResult(List.of(5), List.of(2), false));
+    EasyMock.expect(game.drawCard()).andReturn(card);
+    attacker.addCard(card);
+    EasyMock.replay(attacker, enemy, diceRoller, game, card, s, t1, t2);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.resolveBattle(s, t1, 1);
+    phase.resolveBattle(s, t2, 1);
+    phase.awardCardIfEarned();
+
+    EasyMock.verify(attacker, enemy, diceRoller, game, card, s, t1, t2);
+  }
+
+  @Test
   public void awardCardIfEarned_oneConquest_drawsOneCardAndAddsToAttacker() {
     Player attacker = EasyMock.createMock(Player.class);
     DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -355,4 +355,28 @@ public class AttackPhaseTests {
     assertEquals(0, phase.getConqueredCount());
     EasyMock.verify(attacker, diceRoller, game, s, t);
   }
+
+  @Test
+  public void resolveBattle_conquest_conqueredCountIncrementedAndRemoveTroopsNotCalled() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    List<Integer> attackDice = List.of(6);
+    List<Integer> defendDice = List.of(1);
+    EasyMock.expect(diceRoller.rollAttacker(1)).andReturn(attackDice);
+    EasyMock.expect(t.getTroopCount()).andReturn(1);
+    EasyMock.expect(diceRoller.rollDefender(1)).andReturn(defendDice);
+    EasyMock.expect(diceRoller.compare(attackDice, defendDice))
+        .andReturn(new BattleResult(List.of(6), List.of(1), false));
+    EasyMock.replay(attacker, diceRoller, game, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    phase.resolveBattle(s, t, 1);
+
+    assertEquals(1, phase.getConqueredCount());
+    EasyMock.verify(attacker, diceRoller, game, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -102,4 +102,26 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, diceRoller, game, map, s, t);
   }
+
+  @Test
+  public void canAttack_targetOwnedByAttacker_returnsFalse() {
+    Player attacker = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    GameMap map = EasyMock.createMock(GameMap.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    EasyMock.expect(s.getOwner()).andReturn(attacker);
+    EasyMock.expect(s.getTroopCount()).andReturn(2);
+    EasyMock.expect(game.getMap()).andReturn(map);
+    EasyMock.expect(map.areAdjacent(s, t)).andReturn(true);
+    EasyMock.expect(t.getOwner()).andReturn(attacker);
+    EasyMock.replay(attacker, diceRoller, game, map, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    assertFalse(phase.canAttack(s, t));
+
+    EasyMock.verify(attacker, diceRoller, game, map, s, t);
+  }
 }

--- a/src/test/java/domain/AttackPhaseTests.java
+++ b/src/test/java/domain/AttackPhaseTests.java
@@ -238,4 +238,28 @@ public class AttackPhaseTests {
 
     EasyMock.verify(attacker, enemy, diceRoller, game, s, t);
   }
+
+  @Test
+  public void declareAttack_territoriesNotAdjacent_throwsIllegalArgumentException() {
+    Player attacker = EasyMock.createMock(Player.class);
+    Player enemy = EasyMock.createMock(Player.class);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    Game game = EasyMock.createMock(Game.class);
+    GameMap map = EasyMock.createMock(GameMap.class);
+    Territory s = EasyMock.createMock(Territory.class);
+    Territory t = EasyMock.createMock(Territory.class);
+
+    EasyMock.expect(s.getOwner()).andReturn(attacker);
+    EasyMock.expect(t.getOwner()).andReturn(enemy);
+    EasyMock.expect(s.getTroopCount()).andReturn(2);
+    EasyMock.expect(game.getMap()).andReturn(map);
+    EasyMock.expect(map.areAdjacent(s, t)).andReturn(false);
+    EasyMock.replay(attacker, enemy, diceRoller, game, map, s, t);
+
+    AttackPhase phase = new AttackPhase(attacker, diceRoller, game);
+    assertThrows(IllegalArgumentException.class,
+        () -> phase.declareAttack(s, t, 1));
+
+    EasyMock.verify(attacker, enemy, diceRoller, game, map, s, t);
+  }
 }

--- a/src/test/java/domain/GameTests.java
+++ b/src/test/java/domain/GameTests.java
@@ -721,6 +721,24 @@ public class GameTests {
   }
 
   @Test
+  public void drawCard_twoCardsInDeck_returnsFirstCardAndDeckHasOneRemaining() {
+    GameMap map = makeMap();
+    List<Player> players = makePlayers(2);
+    List<RiskCard> deck = makeCards(2);
+    RiskCard firstCard = deck.get(0);
+    deck.forEach(EasyMock::replay);
+    replayAll(players, map);
+
+    Game game = new Game(players, map, deck, new Random());
+    RiskCard drawn = game.drawCard();
+
+    assertEquals(firstCard, drawn);
+    assertEquals(1, game.getDeckSize());
+    verifyAll(players, map);
+    deck.forEach(EasyMock::verify);
+  }
+
+  @Test
   public void shuffleDeck_emptyDeck_deckRemainsEmpty() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);

--- a/src/test/java/domain/GameTests.java
+++ b/src/test/java/domain/GameTests.java
@@ -673,6 +673,24 @@ public class GameTests {
   }
 
   @Test
+  public void advanceToNextPlayer_threePlayers_indexAtInterior_advancesToTwo() {
+    GameMap map = makeMap();
+    List<Player> players = makePlayers(3);
+    Random random = EasyMock.createMock(Random.class);
+    EasyMock.expect(random.nextInt(3)).andReturn(1);
+    replayAll(players, map);
+    EasyMock.replay(random);
+
+    Game game = new Game(players, map, new ArrayList<>(), random);
+    game.chooseFirstPlayer();
+    game.advanceToNextPlayer();
+
+    assertEquals(2, game.getCurrentPlayerIndex());
+    verifyAll(players, map);
+    EasyMock.verify(random);
+  }
+
+  @Test
   public void shuffleDeck_emptyDeck_deckRemainsEmpty() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);

--- a/src/test/java/domain/GameTests.java
+++ b/src/test/java/domain/GameTests.java
@@ -691,6 +691,18 @@ public class GameTests {
   }
 
   @Test
+  public void drawCard_emptyDeck_throwsIllegalStateException() {
+    GameMap map = makeMap();
+    List<Player> players = makePlayers(2);
+    replayAll(players, map);
+
+    Game game = new Game(players, map, new ArrayList<>(), new Random());
+
+    assertThrows(IllegalStateException.class, () -> game.drawCard());
+    verifyAll(players, map);
+  }
+
+  @Test
   public void shuffleDeck_emptyDeck_deckRemainsEmpty() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);

--- a/src/test/java/domain/GameTests.java
+++ b/src/test/java/domain/GameTests.java
@@ -655,6 +655,24 @@ public class GameTests {
   }
 
   @Test
+  public void advanceToNextPlayer_twoPlayers_indexAtUpperBound_wrapsToZero() {
+    GameMap map = makeMap();
+    List<Player> players = makePlayers(2);
+    Random random = EasyMock.createMock(Random.class);
+    EasyMock.expect(random.nextInt(2)).andReturn(1);
+    replayAll(players, map);
+    EasyMock.replay(random);
+
+    Game game = new Game(players, map, new ArrayList<>(), random);
+    game.chooseFirstPlayer();
+    game.advanceToNextPlayer();
+
+    assertEquals(0, game.getCurrentPlayerIndex());
+    verifyAll(players, map);
+    EasyMock.verify(random);
+  }
+
+  @Test
   public void shuffleDeck_emptyDeck_deckRemainsEmpty() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);

--- a/src/test/java/domain/GameTests.java
+++ b/src/test/java/domain/GameTests.java
@@ -637,6 +637,24 @@ public class GameTests {
   }
 
   @Test
+  public void advanceToNextPlayer_twoPlayers_indexAtLowerBound_advancesToOne() {
+    GameMap map = makeMap();
+    List<Player> players = makePlayers(2);
+    Random random = EasyMock.createMock(Random.class);
+    EasyMock.expect(random.nextInt(2)).andReturn(0);
+    replayAll(players, map);
+    EasyMock.replay(random);
+
+    Game game = new Game(players, map, new ArrayList<>(), random);
+    game.chooseFirstPlayer();
+    game.advanceToNextPlayer();
+
+    assertEquals(1, game.getCurrentPlayerIndex());
+    verifyAll(players, map);
+    EasyMock.verify(random);
+  }
+
+  @Test
   public void shuffleDeck_emptyDeck_deckRemainsEmpty() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);

--- a/src/test/java/domain/GameTests.java
+++ b/src/test/java/domain/GameTests.java
@@ -703,6 +703,24 @@ public class GameTests {
   }
 
   @Test
+  public void drawCard_oneCardInDeck_returnsCardAndDeckIsEmpty() {
+    GameMap map = makeMap();
+    List<Player> players = makePlayers(2);
+    List<RiskCard> deck = makeCards(1);
+    RiskCard card = deck.get(0);
+    EasyMock.replay(card);
+    replayAll(players, map);
+
+    Game game = new Game(players, map, deck, new Random());
+    RiskCard drawn = game.drawCard();
+
+    assertEquals(card, drawn);
+    assertEquals(0, game.getDeckSize());
+    verifyAll(players, map);
+    EasyMock.verify(card);
+  }
+
+  @Test
   public void shuffleDeck_emptyDeck_deckRemainsEmpty() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);

--- a/src/test/java/domain/GameTests.java
+++ b/src/test/java/domain/GameTests.java
@@ -63,68 +63,80 @@ public class GameTests {
   @Test
   public void constructor_nullPlayers_throwsIllegalArgumentException() {
     GameMap map = makeMap();
-    EasyMock.replay(map);
+    Random random = EasyMock.createMock(Random.class);
+    EasyMock.replay(map, random);
     assertThrows(
-        IllegalArgumentException.class, () -> new Game(null, map, new ArrayList<>(), new Random()));
-    EasyMock.verify(map);
+        IllegalArgumentException.class, () -> new Game(null, map, new ArrayList<>(), random));
+    EasyMock.verify(map, random);
   }
 
   @Test
   public void constructor_emptyPlayersList_throwsIllegalArgumentException() {
     GameMap map = makeMap();
-    EasyMock.replay(map);
+    Random random = EasyMock.createMock(Random.class);
+    EasyMock.replay(map, random);
     assertThrows(
         IllegalArgumentException.class,
-        () -> new Game(new ArrayList<>(), map, new ArrayList<>(), new Random()));
-    EasyMock.verify(map);
+        () -> new Game(new ArrayList<>(), map, new ArrayList<>(), random));
+    EasyMock.verify(map, random);
   }
 
   @Test
   public void constructor_onePlayer_throwsIllegalArgumentException() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(1);
+    Random random = EasyMock.createMock(Random.class);
     replayAll(players, map);
+    EasyMock.replay(random);
     assertThrows(
-        IllegalArgumentException.class,
-        () -> new Game(players, map, new ArrayList<>(), new Random()));
+        IllegalArgumentException.class, () -> new Game(players, map, new ArrayList<>(), random));
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 
   @Test
   public void constructor_twoPlayers_gameConstructedWithPlayersAndMap() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);
+    Random random = EasyMock.createMock(Random.class);
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, new ArrayList<>(), new Random());
+    Game game = new Game(players, map, new ArrayList<>(), random);
 
     assertEquals(2, game.getPlayerCount());
     assertEquals(map, game.getMap());
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 
   @Test
   public void constructor_sixPlayers_gameConstructedWithPlayersAndMap() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(6);
+    Random random = EasyMock.createMock(Random.class);
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, new ArrayList<>(), new Random());
+    Game game = new Game(players, map, new ArrayList<>(), random);
 
     assertEquals(6, game.getPlayerCount());
     assertEquals(map, game.getMap());
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 
   @Test
   public void constructor_sevenPlayers_throwsIllegalArgumentException() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(7);
+    Random random = EasyMock.createMock(Random.class);
     replayAll(players, map);
+    EasyMock.replay(random);
     assertThrows(
-        IllegalArgumentException.class,
-        () -> new Game(players, map, new ArrayList<>(), new Random()));
+        IllegalArgumentException.class, () -> new Game(players, map, new ArrayList<>(), random));
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 
   @Test
@@ -139,9 +151,10 @@ public class GameTests {
           }
         });
     EasyMock.replay(map);
+    Random random = EasyMock.createMock(Random.class);
+    EasyMock.replay(random);
     assertThrows(
-        IllegalArgumentException.class,
-        () -> new Game(players, map, new ArrayList<>(), new Random()));
+        IllegalArgumentException.class, () -> new Game(players, map, new ArrayList<>(), random));
     players.forEach(
         p -> {
           if (p != null) {
@@ -149,16 +162,19 @@ public class GameTests {
           }
         });
     EasyMock.verify(map);
+    EasyMock.verify(random);
   }
 
   @Test
   public void constructor_nullMap_throwsIllegalArgumentException() {
     List<Player> players = makePlayers(2);
+    Random random = EasyMock.createMock(Random.class);
     players.forEach(EasyMock::replay);
+    EasyMock.replay(random);
     assertThrows(
-        IllegalArgumentException.class,
-        () -> new Game(players, null, new ArrayList<>(), new Random()));
+        IllegalArgumentException.class, () -> new Game(players, null, new ArrayList<>(), random));
     players.forEach(EasyMock::verify);
+    EasyMock.verify(random);
   }
 
   @Test
@@ -315,6 +331,7 @@ public class GameTests {
   public void distributeStartingTroops_twoPlayers_availableTroopsSetTo40MinusTerritoryCount() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);
+    Random random = EasyMock.createMock(Random.class);
 
     EasyMock.expect(players.get(0).getTerritoryCount()).andReturn(3);
     EasyMock.expect(players.get(1).getTerritoryCount()).andReturn(2);
@@ -322,17 +339,20 @@ public class GameTests {
     players.get(1).setAvailableTroops(38);
 
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, new ArrayList<>(), new Random());
+    Game game = new Game(players, map, new ArrayList<>(), random);
     game.distributeStartingTroops();
 
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 
   @Test
   public void distributeStartingTroops_threePlayers_availableTroopsSetTo35MinusTerritoryCount() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(3);
+    Random random = EasyMock.createMock(Random.class);
 
     EasyMock.expect(players.get(0).getTerritoryCount()).andReturn(5);
     EasyMock.expect(players.get(1).getTerritoryCount()).andReturn(4);
@@ -342,17 +362,20 @@ public class GameTests {
     players.get(2).setAvailableTroops(30);
 
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, new ArrayList<>(), new Random());
+    Game game = new Game(players, map, new ArrayList<>(), random);
     game.distributeStartingTroops();
 
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 
   @Test
   public void distributeStartingTroops_fourPlayers_availableTroopsSetTo30MinusTerritoryCount() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(4);
+    Random random = EasyMock.createMock(Random.class);
 
     EasyMock.expect(players.get(0).getTerritoryCount()).andReturn(3);
     EasyMock.expect(players.get(1).getTerritoryCount()).andReturn(3);
@@ -364,17 +387,20 @@ public class GameTests {
     players.get(3).setAvailableTroops(27);
 
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, new ArrayList<>(), new Random());
+    Game game = new Game(players, map, new ArrayList<>(), random);
     game.distributeStartingTroops();
 
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 
   @Test
   public void distributeStartingTroops_fivePlayers_availableTroopsSetTo25MinusTerritoryCount() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(5);
+    Random random = EasyMock.createMock(Random.class);
 
     EasyMock.expect(players.get(0).getTerritoryCount()).andReturn(2);
     EasyMock.expect(players.get(1).getTerritoryCount()).andReturn(2);
@@ -386,17 +412,20 @@ public class GameTests {
     }
 
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, new ArrayList<>(), new Random());
+    Game game = new Game(players, map, new ArrayList<>(), random);
     game.distributeStartingTroops();
 
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 
   @Test
   public void distributeStartingTroops_sixPlayers_availableTroopsSetTo20MinusTerritoryCount() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(6);
+    Random random = EasyMock.createMock(Random.class);
 
     EasyMock.expect(players.get(0).getTerritoryCount()).andReturn(2);
     EasyMock.expect(players.get(1).getTerritoryCount()).andReturn(2);
@@ -412,11 +441,13 @@ public class GameTests {
     players.get(5).setAvailableTroops(19);
 
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, new ArrayList<>(), new Random());
+    Game game = new Game(players, map, new ArrayList<>(), random);
     game.distributeStartingTroops();
 
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 
   @Test
@@ -491,12 +522,15 @@ public class GameTests {
   public void constructor_validPlayersAndMap_mapStoredCorrectly() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);
+    Random random = EasyMock.createMock(Random.class);
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, new ArrayList<>(), new Random());
+    Game game = new Game(players, map, new ArrayList<>(), random);
 
     assertEquals(map, game.getMap());
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 
   @Test
@@ -589,16 +623,18 @@ public class GameTests {
     List<Player> players = makePlayers(2);
     List<RiskCard> deck = makeCards(1);
     RiskCard card = deck.get(0);
-    EasyMock.replay(card);
+    Random random = EasyMock.createMock(Random.class);
+    // shuffle of size 1 makes no nextInt calls
+    EasyMock.replay(card, random);
     replayAll(players, map);
 
-    Game game = new Game(players, map, deck, new Random());
+    Game game = new Game(players, map, deck, random);
     game.shuffleDeck();
 
     assertEquals(1, game.getDeckSize());
     assertEquals(card, game.getDeck().get(0));
     verifyAll(players, map);
-    EasyMock.verify(card);
+    EasyMock.verify(card, random);
   }
 
   @Test
@@ -606,17 +642,20 @@ public class GameTests {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);
     List<RiskCard> deck = makeCards(2);
+    Random random = EasyMock.createMock(Random.class);
+    expectIdentityShuffle(random, 2);
     deck.forEach(EasyMock::replay);
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, deck, new Random());
+    Game game = new Game(players, map, deck, random);
     game.shuffleDeck();
 
     assertEquals(2, game.getDeckSize());
     assertTrue(game.getDeck().contains(deck.get(0)));
     assertTrue(game.getDeck().contains(deck.get(1)));
-    verifyAll(players, map);
     deck.forEach(EasyMock::verify);
+    EasyMock.verify(random);
   }
 
   @Test
@@ -624,16 +663,19 @@ public class GameTests {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);
     List<RiskCard> deck = makeCards(44);
+    Random random = EasyMock.createMock(Random.class);
+    expectIdentityShuffle(random, 44);
     deck.forEach(EasyMock::replay);
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, deck, new Random());
+    Game game = new Game(players, map, deck, random);
     game.shuffleDeck();
 
     assertEquals(44, game.getDeckSize());
     deck.forEach(card -> assertTrue(game.getDeck().contains(card)));
-    verifyAll(players, map);
     deck.forEach(EasyMock::verify);
+    EasyMock.verify(random);
   }
 
   @Test
@@ -694,12 +736,15 @@ public class GameTests {
   public void drawCard_emptyDeck_throwsIllegalStateException() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);
+    Random random = EasyMock.createMock(Random.class);
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, new ArrayList<>(), new Random());
+    Game game = new Game(players, map, new ArrayList<>(), random);
 
     assertThrows(IllegalStateException.class, () -> game.drawCard());
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 
   @Test
@@ -708,16 +753,17 @@ public class GameTests {
     List<Player> players = makePlayers(2);
     List<RiskCard> deck = makeCards(1);
     RiskCard card = deck.get(0);
-    EasyMock.replay(card);
+    Random random = EasyMock.createMock(Random.class);
+    EasyMock.replay(card, random);
     replayAll(players, map);
 
-    Game game = new Game(players, map, deck, new Random());
+    Game game = new Game(players, map, deck, random);
     RiskCard drawn = game.drawCard();
 
     assertEquals(card, drawn);
     assertEquals(0, game.getDeckSize());
     verifyAll(players, map);
-    EasyMock.verify(card);
+    EasyMock.verify(card, random);
   }
 
   @Test
@@ -726,28 +772,35 @@ public class GameTests {
     List<Player> players = makePlayers(2);
     List<RiskCard> deck = makeCards(2);
     RiskCard firstCard = deck.get(0);
+    Random random = EasyMock.createMock(Random.class);
     deck.forEach(EasyMock::replay);
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, deck, new Random());
+    Game game = new Game(players, map, deck, random);
     RiskCard drawn = game.drawCard();
 
     assertEquals(firstCard, drawn);
     assertEquals(1, game.getDeckSize());
     verifyAll(players, map);
     deck.forEach(EasyMock::verify);
+    EasyMock.verify(random);
   }
 
   @Test
   public void shuffleDeck_emptyDeck_deckRemainsEmpty() {
     GameMap map = makeMap();
     List<Player> players = makePlayers(2);
+    Random random = EasyMock.createMock(Random.class);
+    // shuffle of size 0 makes no nextInt calls
     replayAll(players, map);
+    EasyMock.replay(random);
 
-    Game game = new Game(players, map, new ArrayList<>(), new Random());
+    Game game = new Game(players, map, new ArrayList<>(), random);
     game.shuffleDeck();
 
     assertEquals(0, game.getDeckSize());
     verifyAll(players, map);
+    EasyMock.verify(random);
   }
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why -->

Created AttackPhase class through BVA and TDD. Also added advanceToNextPlayer and drawCard methods to Game class, so it could be used by AttackPhase, and updated its BVA and tests accordingly.

<!-- Link to your project board task, e.g. Closes #123 -->

[Task 1](https://github.com/orgs/nu-cs-sqe/projects/78/views/1?pane=issue&itemId=185390875&issue=nu-cs-sqe%7Ccourse-project-20252603-team-11-20252603%7C44)

[Task 2](https://github.com/orgs/nu-cs-sqe/projects/78/views/1?pane=issue&itemId=185391271&issue=nu-cs-sqe%7Ccourse-project-20252603-team-11-20252603%7C47)

---

## ✅ PR Checklist

### 🧪 Testing

- [x] All existing automated tests pass
- [x] New code is covered by tests written **before** the implementation (TDD/BDD)
- [x] Test inputs and assertions are based on BVA analysis
- [ ] Mutation testing has been run — **100% of non-equivalent mutants are killed**
- [x] **100% cyclomatic coverage** for all non-GUI and non-enum code
- [x] Integration tests updated/added if this PR touches a main feature (at least 2 main features must have integration
  tests by end of project)

### 🎨 Code Quality

- [x] Code fully satisfies the team's agreed style standards
- [x] Code follows **Clean Code** principles (meaningful names, small functions, no dead code, etc.)
- [x] No unnecessary comments and minimal TODOs left in

### 🌍 Localization (i18n)

- [x] Any new user-facing strings are externalized (not hardcoded)
- [x] Adding this change does not require modifying existing locale files to support a new language

### 🔁 Process

- [x] The corresponding task on the project management board is updated with a **detailed description**
- [x] This week's planning/progress notes are up to date in the team's documentation
- [x] This PR targets the correct branch and is **not** a direct push to `main`
- [x] CI pipeline passes ✅

---

## 📸 Screenshots / Evidence (if applicable)

<!-- Add screenshots, test output, or coverage reports here -->
