### PR TITLE
Feature/gui

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,9 @@
 plugins {
     id("java")
+    id("application")
     id("checkstyle")
     id("jacoco")
+    id("org.openjfx.javafxplugin") version "0.1.0"
 }
 
 group = "nu.csse.sqe"
@@ -15,6 +17,15 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.easymock:easymock:5.4.0")
+}
+
+application {
+    mainClass.set("ui.Main")
+}
+
+javafx {
+    version = "17.0.6"
+    modules = listOf("javafx.controls", "javafx.graphics")
 }
 
 java {

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -12,6 +12,9 @@
     <suppress files=".*Tests?\.java" checks="MissingJavadocMethod|MissingJavadocType"/>
 -->
 <suppressions>
+  <!-- i18n is a well-known abbreviation; suppress the digit-in-package-name check. -->
+  <suppress files="i18n[/\\]Messages\.java" checks="PackageName"/>
+
   <!-- Relax stylistic checks in test code. -->
   <suppress files=".*Tests?\.java" checks="VariableDeclarationUsageDistance"/>
   <suppress files=".*Tests?\.java" checks="AbbreviationAsWordInName"/>

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -119,7 +119,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
         - Chin — Gao Ling
         - Gao Ling — Hei Bei
 
-- **TC15: Ocean Tribe intra-faction adjacencies** ( :x: )
+- **TC15: Ocean Tribe intra-faction adjacencies** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned
     - **Expected output**: all 8 edges present and symmetric:
         - Eastern Air Temple — Seafoam Isles

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -142,7 +142,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
     - **Expected output**: Bin-Er ↔ Zigan and Yue Bay ↔ Zigan both adjacent and
       symmetric (Moon Tribe ↔ Ba Sing Se Kingdom)
 
-- **TC18: sea route — Gao Ling to Seafoam Isles** ( :x: )
+- **TC18: sea route — Gao Ling to Seafoam Isles** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned
     - **Expected output**: areAdjacent(Gao Ling, Seafoam Isles) == true and
       areAdjacent(Seafoam Isles, Gao Ling) == true

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -78,7 +78,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
         - Yue Bay — Wulong
         - Wulong — Western Air Temple
 
-- **TC12: Ba Sing Se Kingdom intra-faction adjacencies** ( :x: )
+- **TC12: Ba Sing Se Kingdom intra-faction adjacencies** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned
     - **Expected output**: all 11 edges present and symmetric:
         - Zigan — Northern Air Temple

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -158,7 +158,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
 
 ### Method under test: `continentCount()`
 
-- **TC20: continent count derived from faction structure** ( :x: )
+- **TC20: continent count derived from faction structure** ( :white_check_mark: )
     - **State of the system**: `AtlaMapData` instantiated
     - **Expected output**: `continentCount() == 5`; value is derived from the
       faction data structure, not a literal

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -104,7 +104,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
         - Keonso — Fire Archipelago
         - Fire Archipelago — Whale Tail Isle
 
-- **TC14: Omashu Kingdom intra-faction adjacencies** ( :x: )
+- **TC14: Omashu Kingdom intra-faction adjacencies** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned
     - **Expected output**: all 11 edges present and symmetric:
         - Hei Bei — Great Divide

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -148,7 +148,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
       areAdjacent(Seafoam Isles, Gao Ling) == true
       (Omashu Kingdom ↔ Ocean Tribe)
 
-- **TC19: sea route — Hakoda Island to Chin** ( :x: )
+- **TC19: sea route — Hakoda Island to Chin** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned
     - **Expected output**: areAdjacent(Hakoda Island, Chin) == true and
       areAdjacent(Chin, Hakoda Island) == true

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -62,7 +62,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
     - **Expected output**: for every territory `t`, `t` is not contained in
       `getNeighbors(t)`
 
-- **TC10: no duplicate edges** ( :x: )
+- **TC10: no duplicate edges** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned
     - **Expected output**: for every territory `t`, `getNeighbors(t)` has no
       duplicates (set size equals list size)

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -43,7 +43,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
       Serpent Pass, Full Moon Bay, Omashu, Western Si Wong Desert, Eastern Si
       Wong Desert, Heart Farmlands, Chin, Gao Ling
 
-- **TC6: Ocean Tribe faction count** ( :x: )
+- **TC6: Ocean Tribe faction count** ( :white_check_mark: )
     - **State of the system**: `AtlaMapData` instantiated
     - **Expected output**: exactly 8 territories named: Eastern Air Temple,
       Seafoam Isles, Hakoda Island, Shimsom Isle, Southern Air Temple, Ocean

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -67,7 +67,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
     - **Expected output**: for every territory `t`, `getNeighbors(t)` has no
       duplicates (set size equals list size)
 
-- **TC11: Moon Tribe intra-faction adjacencies** ( :x: )
+- **TC11: Moon Tribe intra-faction adjacencies** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned
     - **Expected output**: all 7 edges present and symmetric (areAdjacent both ways):
         - Northern Tundra — Frost Hills

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -137,7 +137,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
       and areAdjacent(Shimsom Isle, Whale Tail Isle) == true
       (Fire Nation ↔ Ocean Tribe cross-faction)
 
-- **TC17: sea routes — Bin-Er and Yue Bay to Zigan** ( :x: )
+- **TC17: sea routes — Bin-Er and Yue Bay to Zigan** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned
     - **Expected output**: Bin-Er ↔ Zigan and Yue Bay ↔ Zigan both adjacent and
       symmetric (Moon Tribe ↔ Ba Sing Se Kingdom)

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -1,0 +1,164 @@
+# AtlaMapData - BVA Analysis
+
+## Design notes
+
+**Unowned-Territory contract**: `buildMap()` constructs every `Territory` via
+`Territory(String name)`, which encapsulates a `null` owner internally and sets
+`troopCount` to 0. No `null` is ever passed across a call site.
+`Game.assignTerritories()` subsequently calls `setOwner` and `addTroops(1)` on
+each territory during setup.
+
+**Continent seam**: `AtlaMapData` owns the 5 faction groupings (Moon Tribe,
+Ba Sing Se Kingdom, Fire Nation, Omashu Kingdom, Ocean Tribe) and their territory
+membership. `continentCount()` is the single tested source of truth that a future
+`Player.calculateTroops` consumer will call. Do not implement that consumer here.
+
+---
+
+### Method under test: `buildMap()`
+
+- **TC1: total territory count** ( :x: )
+    - **State of the system**: `AtlaMapData` instantiated
+    - **Expected output**: `buildMap().getTerritories().size() == 42`
+
+- **TC2: Moon Tribe faction count** ( :x: )
+    - **State of the system**: `AtlaMapData` instantiated
+    - **Expected output**: exactly 7 territories named: Northern Tundra,
+      Frost Hills, Moon Tribe, Bin-Er, Yue Bay, Wulong, Western Air Temple
+
+- **TC3: Ba Sing Se Kingdom faction count** ( :x: )
+    - **State of the system**: `AtlaMapData` instantiated
+    - **Expected output**: exactly 10 territories named: Zigan, Northern Air
+      Temple, Northern Mountains, Taihua, Ba Sing Se City, Ba Sing Se Province,
+      Continental Corridor, Taku, Green Farmlands, Charmeleon Province
+
+- **TC4: Fire Nation faction count** ( :x: )
+    - **State of the system**: `AtlaMapData` instantiated
+    - **Expected output**: exactly 7 territories named: Sun Isles, Burning Gates,
+      Caldera City, Black Cliffs, Keonso, Fire Archipelago, Whale Tail Isle
+
+- **TC5: Omashu Kingdom faction count** ( :x: )
+    - **State of the system**: `AtlaMapData` instantiated
+    - **Expected output**: exactly 10 territories named: Hei Bei, Great Divide,
+      Serpent Pass, Full Moon Bay, Omashu, Western Si Wong Desert, Eastern Si
+      Wong Desert, Heart Farmlands, Chin, Gao Ling
+
+- **TC6: Ocean Tribe faction count** ( :x: )
+    - **State of the system**: `AtlaMapData` instantiated
+    - **Expected output**: exactly 8 territories named: Eastern Air Temple,
+      Seafoam Isles, Hakoda Island, Shimsom Isle, Southern Air Temple, Ocean
+      Tribe, Southern Tundra, Icy Plains
+
+- **TC7: all territories start unowned** ( :x: )
+    - **State of the system**: `buildMap()` returned; no players assigned
+    - **Expected output**: `getOwner() == null` for every territory in the map
+
+- **TC8: all territories start with zero troops** ( :x: )
+    - **State of the system**: `buildMap()` returned; no players assigned
+    - **Expected output**: `getTroopCount() == 0` for every territory in the map
+
+- **TC9: no self-loops** ( :x: )
+    - **State of the system**: `buildMap()` returned
+    - **Expected output**: for every territory `t`, `t` is not contained in
+      `getNeighbors(t)`
+
+- **TC10: no duplicate edges** ( :x: )
+    - **State of the system**: `buildMap()` returned
+    - **Expected output**: for every territory `t`, `getNeighbors(t)` has no
+      duplicates (set size equals list size)
+
+- **TC11: Moon Tribe intra-faction adjacencies** ( :x: )
+    - **State of the system**: `buildMap()` returned
+    - **Expected output**: all 7 edges present and symmetric (areAdjacent both ways):
+        - Northern Tundra — Frost Hills
+        - Northern Tundra — Moon Tribe
+        - Frost Hills — Bin-Er
+        - Moon Tribe — Bin-Er
+        - Bin-Er — Yue Bay
+        - Yue Bay — Wulong
+        - Wulong — Western Air Temple
+
+- **TC12: Ba Sing Se Kingdom intra-faction adjacencies** ( :x: )
+    - **State of the system**: `buildMap()` returned
+    - **Expected output**: all 11 edges present and symmetric:
+        - Zigan — Northern Air Temple
+        - Zigan — Northern Mountains
+        - Northern Air Temple — Northern Mountains
+        - Northern Mountains — Taihua
+        - Taihua — Ba Sing Se City
+        - Ba Sing Se City — Ba Sing Se Province
+        - Ba Sing Se Province — Continental Corridor
+        - Continental Corridor — Taku
+        - Taku — Green Farmlands
+        - Green Farmlands — Charmeleon Province
+        - Charmeleon Province — Ba Sing Se Province
+
+- **TC13: Fire Nation intra-faction adjacencies** ( :x: )
+    - **State of the system**: `buildMap()` returned
+    - **Expected output**: all 7 edges present and symmetric:
+        - Sun Isles — Burning Gates
+        - Sun Isles — Caldera City
+        - Burning Gates — Caldera City
+        - Caldera City — Black Cliffs
+        - Black Cliffs — Keonso
+        - Keonso — Fire Archipelago
+        - Fire Archipelago — Whale Tail Isle
+
+- **TC14: Omashu Kingdom intra-faction adjacencies** ( :x: )
+    - **State of the system**: `buildMap()` returned
+    - **Expected output**: all 11 edges present and symmetric:
+        - Hei Bei — Great Divide
+        - Great Divide — Serpent Pass
+        - Serpent Pass — Full Moon Bay
+        - Full Moon Bay — Omashu
+        - Omashu — Western Si Wong Desert
+        - Omashu — Eastern Si Wong Desert
+        - Western Si Wong Desert — Heart Farmlands
+        - Eastern Si Wong Desert — Heart Farmlands
+        - Heart Farmlands — Chin
+        - Chin — Gao Ling
+        - Gao Ling — Hei Bei
+
+- **TC15: Ocean Tribe intra-faction adjacencies** ( :x: )
+    - **State of the system**: `buildMap()` returned
+    - **Expected output**: all 8 edges present and symmetric:
+        - Eastern Air Temple — Seafoam Isles
+        - Seafoam Isles — Hakoda Island
+        - Hakoda Island — Shimsom Isle
+        - Shimsom Isle — Southern Air Temple
+        - Southern Air Temple — Ocean Tribe
+        - Ocean Tribe — Southern Tundra
+        - Southern Tundra — Icy Plains
+        - Icy Plains — Eastern Air Temple
+
+- **TC16: sea route — Whale Tail Isle to Shimsom Isle** ( :x: )
+    - **State of the system**: `buildMap()` returned
+    - **Expected output**: areAdjacent(Whale Tail Isle, Shimsom Isle) == true
+      and areAdjacent(Shimsom Isle, Whale Tail Isle) == true
+      (Fire Nation ↔ Ocean Tribe cross-faction)
+
+- **TC17: sea routes — Bin-Er and Yue Bay to Zigan** ( :x: )
+    - **State of the system**: `buildMap()` returned
+    - **Expected output**: Bin-Er ↔ Zigan and Yue Bay ↔ Zigan both adjacent and
+      symmetric (Moon Tribe ↔ Ba Sing Se Kingdom)
+
+- **TC18: sea route — Gao Ling to Seafoam Isles** ( :x: )
+    - **State of the system**: `buildMap()` returned
+    - **Expected output**: areAdjacent(Gao Ling, Seafoam Isles) == true and
+      areAdjacent(Seafoam Isles, Gao Ling) == true
+      (Omashu Kingdom ↔ Ocean Tribe)
+
+- **TC19: sea route — Hakoda Island to Chin** ( :x: )
+    - **State of the system**: `buildMap()` returned
+    - **Expected output**: areAdjacent(Hakoda Island, Chin) == true and
+      areAdjacent(Chin, Hakoda Island) == true
+      (Ocean Tribe ↔ Omashu Kingdom)
+
+---
+
+### Method under test: `continentCount()`
+
+- **TC20: continent count derived from faction structure** ( :x: )
+    - **State of the system**: `AtlaMapData` instantiated
+    - **Expected output**: `continentCount() == 5`; value is derived from the
+      faction data structure, not a literal

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -26,7 +26,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
     - **Expected output**: exactly 7 territories named: Northern Tundra,
       Frost Hills, Moon Tribe, Bin-Er, Yue Bay, Wulong, Western Air Temple
 
-- **TC3: Ba Sing Se Kingdom faction count** ( :x: )
+- **TC3: Ba Sing Se Kingdom faction count** ( :white_check_mark: )
     - **State of the system**: `AtlaMapData` instantiated
     - **Expected output**: exactly 10 territories named: Zigan, Northern Air
       Temple, Northern Mountains, Taihua, Ba Sing Se City, Ba Sing Se Province,

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -57,7 +57,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
     - **State of the system**: `buildMap()` returned; no players assigned
     - **Expected output**: `getTroopCount() == 0` for every territory in the map
 
-- **TC9: no self-loops** ( :x: )
+- **TC9: no self-loops** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned
     - **Expected output**: for every territory `t`, `t` is not contained in
       `getNeighbors(t)`

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -17,7 +17,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
 
 ### Method under test: `buildMap()`
 
-- **TC1: total territory count** ( :x: )
+- **TC1: total territory count** ( :white_check_mark: )
     - **State of the system**: `AtlaMapData` instantiated
     - **Expected output**: `buildMap().getTerritories().size() == 42`
 

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -131,7 +131,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
         - Southern Tundra — Icy Plains
         - Icy Plains — Eastern Air Temple
 
-- **TC16: sea route — Whale Tail Isle to Shimsom Isle** ( :x: )
+- **TC16: sea route — Whale Tail Isle to Shimsom Isle** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned
     - **Expected output**: areAdjacent(Whale Tail Isle, Shimsom Isle) == true
       and areAdjacent(Shimsom Isle, Whale Tail Isle) == true

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -37,7 +37,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
     - **Expected output**: exactly 7 territories named: Sun Isles, Burning Gates,
       Caldera City, Black Cliffs, Keonso, Fire Archipelago, Whale Tail Isle
 
-- **TC5: Omashu Kingdom faction count** ( :x: )
+- **TC5: Omashu Kingdom faction count** ( :white_check_mark: )
     - **State of the system**: `AtlaMapData` instantiated
     - **Expected output**: exactly 10 territories named: Hei Bei, Great Divide,
       Serpent Pass, Full Moon Bay, Omashu, Western Si Wong Desert, Eastern Si

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -49,7 +49,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
       Seafoam Isles, Hakoda Island, Shimsom Isle, Southern Air Temple, Ocean
       Tribe, Southern Tundra, Icy Plains
 
-- **TC7: all territories start unowned** ( :x: )
+- **TC7: all territories start unowned** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned; no players assigned
     - **Expected output**: `getOwner() == null` for every territory in the map
 

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -53,7 +53,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
     - **State of the system**: `buildMap()` returned; no players assigned
     - **Expected output**: `getOwner() == null` for every territory in the map
 
-- **TC8: all territories start with zero troops** ( :x: )
+- **TC8: all territories start with zero troops** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned; no players assigned
     - **Expected output**: `getTroopCount() == 0` for every territory in the map
 

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -21,7 +21,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
     - **State of the system**: `AtlaMapData` instantiated
     - **Expected output**: `buildMap().getTerritories().size() == 42`
 
-- **TC2: Moon Tribe faction count** ( :x: )
+- **TC2: Moon Tribe faction count** ( :white_check_mark: )
     - **State of the system**: `AtlaMapData` instantiated
     - **Expected output**: exactly 7 territories named: Northern Tundra,
       Frost Hills, Moon Tribe, Bin-Er, Yue Bay, Wulong, Western Air Temple

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -32,7 +32,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
       Temple, Northern Mountains, Taihua, Ba Sing Se City, Ba Sing Se Province,
       Continental Corridor, Taku, Green Farmlands, Charmeleon Province
 
-- **TC4: Fire Nation faction count** ( :x: )
+- **TC4: Fire Nation faction count** ( :white_check_mark: )
     - **State of the system**: `AtlaMapData` instantiated
     - **Expected output**: exactly 7 territories named: Sun Isles, Burning Gates,
       Caldera City, Black Cliffs, Keonso, Fire Archipelago, Whale Tail Isle

--- a/docs/bva/AtlaMapData.md
+++ b/docs/bva/AtlaMapData.md
@@ -93,7 +93,7 @@ membership. `continentCount()` is the single tested source of truth that a futur
         - Green Farmlands — Charmeleon Province
         - Charmeleon Province — Ba Sing Se Province
 
-- **TC13: Fire Nation intra-faction adjacencies** ( :x: )
+- **TC13: Fire Nation intra-faction adjacencies** ( :white_check_mark: )
     - **State of the system**: `buildMap()` returned
     - **Expected output**: all 7 edges present and symmetric:
         - Sun Isles — Burning Gates

--- a/docs/bva/Territory.md
+++ b/docs/bva/Territory.md
@@ -9,6 +9,14 @@
 | Test Case 4 | null Player       | IllegalArgumentException thrown | :white_check_mark: |
 | Test Case 5 | valid Player      | this.player = Player            | :white_check_mark: |
 
+## Territory(String name)
+
+|              | System under test | Expected output                                                       | Implemented? |
+|--------------|-------------------|-----------------------------------------------------------------------|--------------|
+| Test Case 15 | null name         | IllegalArgumentException thrown                                       | :x:          |
+| Test Case 16 | empty name        | IllegalArgumentException thrown                                       | :x:          |
+| Test Case 17 | valid name        | getName() == name; getOwner() == null (unowned); getTroopCount() == 0 | :x:          |
+
 ## getName()
 
 Getter

--- a/docs/bva/Territory.md
+++ b/docs/bva/Territory.md
@@ -13,7 +13,7 @@
 
 |              | System under test | Expected output                                                       | Implemented? |
 |--------------|-------------------|-----------------------------------------------------------------------|--------------|
-| Test Case 15 | null name         | IllegalArgumentException thrown                                       | :x:          |
+| Test Case 15 | null name         | IllegalArgumentException thrown                                       | :white_check_mark: |
 | Test Case 16 | empty name        | IllegalArgumentException thrown                                       | :x:          |
 | Test Case 17 | valid name        | getName() == name; getOwner() == null (unowned); getTroopCount() == 0 | :x:          |
 

--- a/docs/bva/Territory.md
+++ b/docs/bva/Territory.md
@@ -14,7 +14,7 @@
 |              | System under test | Expected output                                                       | Implemented? |
 |--------------|-------------------|-----------------------------------------------------------------------|--------------|
 | Test Case 15 | null name         | IllegalArgumentException thrown                                       | :white_check_mark: |
-| Test Case 16 | empty name        | IllegalArgumentException thrown                                       | :x:          |
+| Test Case 16 | empty name        | IllegalArgumentException thrown                                       | :white_check_mark: |
 | Test Case 17 | valid name        | getName() == name; getOwner() == null (unowned); getTroopCount() == 0 | :x:          |
 
 ## getName()

--- a/docs/bva/Territory.md
+++ b/docs/bva/Territory.md
@@ -15,7 +15,7 @@
 |--------------|-------------------|-----------------------------------------------------------------------|--------------|
 | Test Case 15 | null name         | IllegalArgumentException thrown                                       | :white_check_mark: |
 | Test Case 16 | empty name        | IllegalArgumentException thrown                                       | :white_check_mark: |
-| Test Case 17 | valid name        | getName() == name; getOwner() == null (unowned); getTroopCount() == 0 | :x:          |
+| Test Case 17 | valid name        | getName() == name; getOwner() == null (unowned); getTroopCount() == 0 | :white_check_mark: |
 
 ## getName()
 

--- a/src/main/java/domain/AtlaMapData.java
+++ b/src/main/java/domain/AtlaMapData.java
@@ -116,6 +116,10 @@ public class AtlaMapData {
     return gameMap;
   }
 
+  public int continentCount() {
+    return FACTION_TERRITORIES.size();
+  }
+
   private static void addEdge(
       GameMap gameMap, Map<String, Territory> byName, String[] edge) {
     gameMap.addConnection(byName.get(edge[0]), byName.get(edge[1]));

--- a/src/main/java/domain/AtlaMapData.java
+++ b/src/main/java/domain/AtlaMapData.java
@@ -1,0 +1,123 @@
+package domain;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AtlaMapData {
+
+  private enum Faction {
+    MOON_TRIBE,
+    BA_SING_SE_KINGDOM,
+    FIRE_NATION,
+    OMASHU_KINGDOM,
+    OCEAN_TRIBE
+  }
+
+  private static final Map<Faction, List<String>> FACTION_TERRITORIES =
+      buildFactionTerritories();
+
+  private static final String[][] INTRA_EDGES = {
+    {"Northern Tundra", "Frost Hills"},
+    {"Northern Tundra", "Moon Tribe"},
+    {"Frost Hills", "Bin-Er"},
+    {"Moon Tribe", "Bin-Er"},
+    {"Bin-Er", "Yue Bay"},
+    {"Yue Bay", "Wulong"},
+    {"Wulong", "Western Air Temple"},
+    {"Zigan", "Northern Air Temple"},
+    {"Zigan", "Northern Mountains"},
+    {"Northern Air Temple", "Northern Mountains"},
+    {"Northern Mountains", "Taihua"},
+    {"Taihua", "Ba Sing Se City"},
+    {"Ba Sing Se City", "Ba Sing Se Province"},
+    {"Ba Sing Se Province", "Continental Corridor"},
+    {"Continental Corridor", "Taku"},
+    {"Taku", "Green Farmlands"},
+    {"Green Farmlands", "Charmeleon Province"},
+    {"Charmeleon Province", "Ba Sing Se Province"},
+    {"Sun Isles", "Burning Gates"},
+    {"Sun Isles", "Caldera City"},
+    {"Burning Gates", "Caldera City"},
+    {"Caldera City", "Black Cliffs"},
+    {"Black Cliffs", "Keonso"},
+    {"Keonso", "Fire Archipelago"},
+    {"Fire Archipelago", "Whale Tail Isle"},
+    {"Hei Bei", "Great Divide"},
+    {"Great Divide", "Serpent Pass"},
+    {"Serpent Pass", "Full Moon Bay"},
+    {"Full Moon Bay", "Omashu"},
+    {"Omashu", "Western Si Wong Desert"},
+    {"Omashu", "Eastern Si Wong Desert"},
+    {"Western Si Wong Desert", "Heart Farmlands"},
+    {"Eastern Si Wong Desert", "Heart Farmlands"},
+    {"Heart Farmlands", "Chin"},
+    {"Chin", "Gao Ling"},
+    {"Gao Ling", "Hei Bei"},
+    {"Eastern Air Temple", "Seafoam Isles"},
+    {"Seafoam Isles", "Hakoda Island"},
+    {"Hakoda Island", "Shimsom Isle"},
+    {"Shimsom Isle", "Southern Air Temple"},
+    {"Southern Air Temple", "Ocean Tribe"},
+    {"Ocean Tribe", "Southern Tundra"},
+    {"Southern Tundra", "Icy Plains"},
+    {"Icy Plains", "Eastern Air Temple"},
+  };
+
+  private static final String[][] CROSS_EDGES = {
+    {"Whale Tail Isle", "Shimsom Isle"},
+    {"Bin-Er", "Zigan"},
+    {"Yue Bay", "Zigan"},
+    {"Gao Ling", "Seafoam Isles"},
+    {"Hakoda Island", "Chin"},
+  };
+
+  private static Map<Faction, List<String>> buildFactionTerritories() {
+    Map<Faction, List<String>> fm = new EnumMap<>(Faction.class);
+    fm.put(Faction.MOON_TRIBE, Arrays.asList(
+        "Northern Tundra", "Frost Hills", "Moon Tribe", "Bin-Er",
+        "Yue Bay", "Wulong", "Western Air Temple"));
+    fm.put(Faction.BA_SING_SE_KINGDOM, Arrays.asList(
+        "Zigan", "Northern Air Temple", "Northern Mountains", "Taihua",
+        "Ba Sing Se City", "Ba Sing Se Province", "Continental Corridor",
+        "Taku", "Green Farmlands", "Charmeleon Province"));
+    fm.put(Faction.FIRE_NATION, Arrays.asList(
+        "Sun Isles", "Burning Gates", "Caldera City", "Black Cliffs",
+        "Keonso", "Fire Archipelago", "Whale Tail Isle"));
+    fm.put(Faction.OMASHU_KINGDOM, Arrays.asList(
+        "Hei Bei", "Great Divide", "Serpent Pass", "Full Moon Bay",
+        "Omashu", "Western Si Wong Desert", "Eastern Si Wong Desert",
+        "Heart Farmlands", "Chin", "Gao Ling"));
+    fm.put(Faction.OCEAN_TRIBE, Arrays.asList(
+        "Eastern Air Temple", "Seafoam Isles", "Hakoda Island", "Shimsom Isle",
+        "Southern Air Temple", "Ocean Tribe", "Southern Tundra", "Icy Plains"));
+    return Collections.unmodifiableMap(fm);
+  }
+
+  public GameMap buildMap() {
+    GameMap gameMap = new GameMap();
+    Map<String, Territory> byName = new HashMap<>();
+    for (List<String> names : FACTION_TERRITORIES.values()) {
+      for (String name : names) {
+        Territory territory = new Territory(name);
+        byName.put(name, territory);
+        gameMap.addTerritory(territory);
+      }
+    }
+    for (String[] edge : INTRA_EDGES) {
+      addEdge(gameMap, byName, edge);
+    }
+    for (String[] edge : CROSS_EDGES) {
+      addEdge(gameMap, byName, edge);
+    }
+    return gameMap;
+  }
+
+  private static void addEdge(
+      GameMap gameMap, Map<String, Territory> byName, String[] edge) {
+    gameMap.addConnection(byName.get(edge[0]), byName.get(edge[1]));
+  }
+}

--- a/src/main/java/domain/Territory.java
+++ b/src/main/java/domain/Territory.java
@@ -5,6 +5,15 @@ public class Territory {
   private Player owner;
   private int troopCount;
 
+  public Territory(String name) {
+    if (name == null || name.isEmpty()) {
+      throw new IllegalArgumentException("Territory name cannot be null or empty.");
+    }
+    this.name = name;
+    this.owner = null;
+    this.troopCount = 0;
+  }
+
   public Territory(String name, Player owner, int troopCount) {
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException("Territory name cannot be null or empty.");

--- a/src/main/java/i18n/Messages.java
+++ b/src/main/java/i18n/Messages.java
@@ -1,0 +1,16 @@
+package i18n;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+public class Messages {
+
+  private static final ResourceBundle BUNDLE =
+      ResourceBundle.getBundle("i18n.messages", Locale.getDefault());
+
+  private Messages() {}
+
+  public static String get(String key) {
+    return BUNDLE.getString(key);
+  }
+}

--- a/src/main/java/ui/Main.java
+++ b/src/main/java/ui/Main.java
@@ -2,15 +2,21 @@ package ui;
 
 import javafx.application.Application;
 import javafx.scene.Scene;
-import javafx.scene.layout.StackPane;
+import javafx.scene.control.ScrollPane;
 import javafx.stage.Stage;
 
 public class Main extends Application {
 
+  private static final String APP_TITLE = "ATLA Risk";
+  private static final double SCENE_WIDTH = 1100.0;
+  private static final double SCENE_HEIGHT = 750.0;
+
   @Override
   public void start(Stage primaryStage) {
-    primaryStage.setTitle("ATLA Risk");
-    primaryStage.setScene(new Scene(new StackPane(), 800, 600));
+    ScrollPane scroll = new ScrollPane(new MapView());
+    scroll.setPannable(true);
+    primaryStage.setTitle(APP_TITLE);
+    primaryStage.setScene(new Scene(scroll, SCENE_WIDTH, SCENE_HEIGHT));
     primaryStage.show();
   }
 

--- a/src/main/java/ui/Main.java
+++ b/src/main/java/ui/Main.java
@@ -1,5 +1,20 @@
 package ui;
 
-public class Main {
-  public static void main(String[] args) {}
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+public class Main extends Application {
+
+  @Override
+  public void start(Stage primaryStage) {
+    primaryStage.setTitle("ATLA Risk");
+    primaryStage.setScene(new Scene(new StackPane(), 800, 600));
+    primaryStage.show();
+  }
+
+  public static void main(String[] args) {
+    launch(args);
+  }
 }

--- a/src/main/java/ui/Main.java
+++ b/src/main/java/ui/Main.java
@@ -1,1 +1,5 @@
+package ui;
 
+public class Main {
+  public static void main(String[] args) {}
+}

--- a/src/main/java/ui/MapView.java
+++ b/src/main/java/ui/MapView.java
@@ -1,0 +1,217 @@
+package ui;
+
+import domain.AtlaMapData;
+import domain.GameMap;
+import domain.Territory;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javafx.scene.Group;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Line;
+
+public class MapView extends Pane {
+
+  private static final double MAP_WIDTH = 1100.0;
+  private static final double MAP_HEIGHT = 750.0;
+  private static final double HEX_RADIUS = 32.0;
+  private static final double EDGE_WIDTH = 1.0;
+  private static final Color EDGE_COLOR = Color.DARKGRAY;
+  private static final Color COLOR_MOON = Color.LIGHTGRAY;
+  private static final Color COLOR_BA_SING_SE = Color.LIGHTGREEN;
+  private static final Color COLOR_FIRE = Color.SALMON;
+  private static final Color COLOR_OMASHU = Color.TAN;
+  private static final Color COLOR_OCEAN = Color.LIGHTSKYBLUE;
+  private static final String BACKGROUND_CSS = "-fx-background-color: aliceblue;";
+
+  private static final Map<String, double[]> POSITIONS = buildPositions();
+  private static final Map<String, String> MSG_KEYS = buildMsgKeys();
+  private static final Map<String, Color> COLORS = buildColors();
+
+  public MapView() {
+    setPrefSize(MAP_WIDTH, MAP_HEIGHT);
+    setStyle(BACKGROUND_CSS);
+    GameMap gameMap = new AtlaMapData().buildMap();
+    getChildren().addAll(buildEdges(gameMap), buildNodes(gameMap));
+  }
+
+  private static Group buildEdges(GameMap gameMap) {
+    Group group = new Group();
+    Set<String> drawn = new HashSet<>();
+    for (Territory ta : gameMap.getTerritories()) {
+      double[] posA = POSITIONS.get(ta.getName());
+      for (Territory tb : gameMap.getNeighbors(ta)) {
+        String ek = edgeKey(ta.getName(), tb.getName());
+        if (drawn.add(ek)) {
+          double[] posB = POSITIONS.get(tb.getName());
+          Line line = new Line(posA[0], posA[1], posB[0], posB[1]);
+          line.setStroke(EDGE_COLOR);
+          line.setStrokeWidth(EDGE_WIDTH);
+          group.getChildren().add(line);
+        }
+      }
+    }
+    return group;
+  }
+
+  private static Group buildNodes(GameMap gameMap) {
+    Group group = new Group();
+    for (Territory territory : gameMap.getTerritories()) {
+      String name = territory.getName();
+      double[] pos = POSITIONS.get(name);
+      String key = MSG_KEYS.get(name);
+      Color color = COLORS.get(name);
+      TerritoryNode node = new TerritoryNode(
+          territory, color, pos[0], pos[1], HEX_RADIUS, key);
+      group.getChildren().add(node);
+    }
+    return group;
+  }
+
+  private static String edgeKey(String nameA, String nameB) {
+    return nameA.compareTo(nameB) < 0 ? nameA + "|" + nameB : nameB + "|" + nameA;
+  }
+
+  private static Map<String, double[]> buildPositions() {
+    Map<String, double[]> pm = new HashMap<>();
+    pm.put("Northern Tundra",       new double[]{110.0,  75.0});
+    pm.put("Frost Hills",           new double[]{200.0,  75.0});
+    pm.put("Moon Tribe",            new double[]{155.0, 145.0});
+    pm.put("Bin-Er",                new double[]{275.0, 115.0});
+    pm.put("Yue Bay",               new double[]{355.0,  80.0});
+    pm.put("Wulong",                new double[]{305.0, 170.0});
+    pm.put("Western Air Temple",    new double[]{190.0, 215.0});
+    pm.put("Zigan",                 new double[]{445.0, 115.0});
+    pm.put("Northern Air Temple",   new double[]{540.0,  85.0});
+    pm.put("Northern Mountains",    new double[]{625.0, 145.0});
+    pm.put("Taihua",                new double[]{550.0, 190.0});
+    pm.put("Ba Sing Se City",       new double[]{645.0, 230.0});
+    pm.put("Ba Sing Se Province",   new double[]{715.0, 290.0});
+    pm.put("Continental Corridor",  new double[]{620.0, 315.0});
+    pm.put("Taku",                  new double[]{540.0, 330.0});
+    pm.put("Green Farmlands",       new double[]{585.0, 400.0});
+    pm.put("Charmeleon Province",   new double[]{685.0, 385.0});
+    pm.put("Sun Isles",             new double[]{860.0, 260.0});
+    pm.put("Burning Gates",         new double[]{935.0, 320.0});
+    pm.put("Caldera City",          new double[]{860.0, 355.0});
+    pm.put("Black Cliffs",          new double[]{940.0, 420.0});
+    pm.put("Keonso",                new double[]{860.0, 445.0});
+    pm.put("Fire Archipelago",      new double[]{940.0, 505.0});
+    pm.put("Whale Tail Isle",       new double[]{860.0, 540.0});
+    pm.put("Hei Bei",               new double[]{415.0, 265.0});
+    pm.put("Great Divide",          new double[]{470.0, 320.0});
+    pm.put("Serpent Pass",          new double[]{525.0, 385.0});
+    pm.put("Full Moon Bay",         new double[]{450.0, 405.0});
+    pm.put("Omashu",                new double[]{385.0, 450.0});
+    pm.put("Western Si Wong Desert", new double[]{305.0, 440.0});
+    pm.put("Eastern Si Wong Desert", new double[]{455.0, 500.0});
+    pm.put("Heart Farmlands",       new double[]{375.0, 500.0});
+    pm.put("Chin",                  new double[]{485.0, 550.0});
+    pm.put("Gao Ling",              new double[]{390.0, 565.0});
+    pm.put("Eastern Air Temple",    new double[]{565.0, 560.0});
+    pm.put("Seafoam Isles",         new double[]{495.0, 620.0});
+    pm.put("Hakoda Island",         new double[]{410.0, 660.0});
+    pm.put("Shimsom Isle",          new double[]{635.0, 630.0});
+    pm.put("Southern Air Temple",   new double[]{705.0, 565.0});
+    pm.put("Ocean Tribe",           new double[]{300.0, 665.0});
+    pm.put("Southern Tundra",       new double[]{190.0, 640.0});
+    pm.put("Icy Plains",            new double[]{100.0, 670.0});
+    return pm;
+  }
+
+  private static Map<String, String> buildMsgKeys() {
+    Map<String, String> mk = new HashMap<>();
+    mk.put("Northern Tundra",       "territory.northernTundra");
+    mk.put("Frost Hills",           "territory.frostHills");
+    mk.put("Moon Tribe",            "territory.moonTribe");
+    mk.put("Bin-Er",                "territory.binEr");
+    mk.put("Yue Bay",               "territory.yueBay");
+    mk.put("Wulong",                "territory.wulong");
+    mk.put("Western Air Temple",    "territory.westernAirTemple");
+    mk.put("Zigan",                 "territory.zigan");
+    mk.put("Northern Air Temple",   "territory.northernAirTemple");
+    mk.put("Northern Mountains",    "territory.northernMountains");
+    mk.put("Taihua",                "territory.taihua");
+    mk.put("Ba Sing Se City",       "territory.baSingSeCity");
+    mk.put("Ba Sing Se Province",   "territory.baSingSeProvince");
+    mk.put("Continental Corridor",  "territory.continentalCorridor");
+    mk.put("Taku",                  "territory.taku");
+    mk.put("Green Farmlands",       "territory.greenFarmlands");
+    mk.put("Charmeleon Province",   "territory.charmeleonProvince");
+    mk.put("Sun Isles",             "territory.sunIsles");
+    mk.put("Burning Gates",         "territory.burningGates");
+    mk.put("Caldera City",          "territory.calderaCity");
+    mk.put("Black Cliffs",          "territory.blackCliffs");
+    mk.put("Keonso",                "territory.keonso");
+    mk.put("Fire Archipelago",      "territory.fireArchipelago");
+    mk.put("Whale Tail Isle",       "territory.whaleTailIsle");
+    mk.put("Hei Bei",               "territory.heiBei");
+    mk.put("Great Divide",          "territory.greatDivide");
+    mk.put("Serpent Pass",          "territory.serpentPass");
+    mk.put("Full Moon Bay",         "territory.fullMoonBay");
+    mk.put("Omashu",                "territory.omashu");
+    mk.put("Western Si Wong Desert", "territory.westernSiWongDesert");
+    mk.put("Eastern Si Wong Desert", "territory.easternSiWongDesert");
+    mk.put("Heart Farmlands",       "territory.heartFarmlands");
+    mk.put("Chin",                  "territory.chin");
+    mk.put("Gao Ling",              "territory.gaoLing");
+    mk.put("Eastern Air Temple",    "territory.easternAirTemple");
+    mk.put("Seafoam Isles",         "territory.seafoamIsles");
+    mk.put("Hakoda Island",         "territory.hakodaIsland");
+    mk.put("Shimsom Isle",          "territory.shimsomIsle");
+    mk.put("Southern Air Temple",   "territory.southernAirTemple");
+    mk.put("Ocean Tribe",           "territory.oceanTribe");
+    mk.put("Southern Tundra",       "territory.southernTundra");
+    mk.put("Icy Plains",            "territory.icyPlains");
+    return mk;
+  }
+
+  private static Map<String, Color> buildColors() {
+    Map<String, Color> cm = new HashMap<>();
+    cm.put("Northern Tundra",       COLOR_MOON);
+    cm.put("Frost Hills",           COLOR_MOON);
+    cm.put("Moon Tribe",            COLOR_MOON);
+    cm.put("Bin-Er",                COLOR_MOON);
+    cm.put("Yue Bay",               COLOR_MOON);
+    cm.put("Wulong",                COLOR_MOON);
+    cm.put("Western Air Temple",    COLOR_MOON);
+    cm.put("Zigan",                 COLOR_BA_SING_SE);
+    cm.put("Northern Air Temple",   COLOR_BA_SING_SE);
+    cm.put("Northern Mountains",    COLOR_BA_SING_SE);
+    cm.put("Taihua",                COLOR_BA_SING_SE);
+    cm.put("Ba Sing Se City",       COLOR_BA_SING_SE);
+    cm.put("Ba Sing Se Province",   COLOR_BA_SING_SE);
+    cm.put("Continental Corridor",  COLOR_BA_SING_SE);
+    cm.put("Taku",                  COLOR_BA_SING_SE);
+    cm.put("Green Farmlands",       COLOR_BA_SING_SE);
+    cm.put("Charmeleon Province",   COLOR_BA_SING_SE);
+    cm.put("Sun Isles",             COLOR_FIRE);
+    cm.put("Burning Gates",         COLOR_FIRE);
+    cm.put("Caldera City",          COLOR_FIRE);
+    cm.put("Black Cliffs",          COLOR_FIRE);
+    cm.put("Keonso",                COLOR_FIRE);
+    cm.put("Fire Archipelago",      COLOR_FIRE);
+    cm.put("Whale Tail Isle",       COLOR_FIRE);
+    cm.put("Hei Bei",               COLOR_OMASHU);
+    cm.put("Great Divide",          COLOR_OMASHU);
+    cm.put("Serpent Pass",          COLOR_OMASHU);
+    cm.put("Full Moon Bay",         COLOR_OMASHU);
+    cm.put("Omashu",                COLOR_OMASHU);
+    cm.put("Western Si Wong Desert", COLOR_OMASHU);
+    cm.put("Eastern Si Wong Desert", COLOR_OMASHU);
+    cm.put("Heart Farmlands",       COLOR_OMASHU);
+    cm.put("Chin",                  COLOR_OMASHU);
+    cm.put("Gao Ling",              COLOR_OMASHU);
+    cm.put("Eastern Air Temple",    COLOR_OCEAN);
+    cm.put("Seafoam Isles",         COLOR_OCEAN);
+    cm.put("Hakoda Island",         COLOR_OCEAN);
+    cm.put("Shimsom Isle",          COLOR_OCEAN);
+    cm.put("Southern Air Temple",   COLOR_OCEAN);
+    cm.put("Ocean Tribe",           COLOR_OCEAN);
+    cm.put("Southern Tundra",       COLOR_OCEAN);
+    cm.put("Icy Plains",            COLOR_OCEAN);
+    return cm;
+  }
+}

--- a/src/main/java/ui/TerritoryNode.java
+++ b/src/main/java/ui/TerritoryNode.java
@@ -1,0 +1,61 @@
+package ui;
+
+import domain.Territory;
+import i18n.Messages;
+import javafx.scene.Cursor;
+import javafx.scene.Group;
+import javafx.scene.control.Tooltip;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Polygon;
+import javafx.scene.text.Text;
+
+public class TerritoryNode extends Group {
+
+  private static final double STROKE_WIDTH = 1.5;
+  private static final double OWNER_RADIUS = 8.0;
+  private static final double OWNER_OFFSET = 0.55;
+  private static final double LABEL_DX = -8.0;
+  private static final double LABEL_DY = 5.0;
+  private static final int HEX_SIDES = 6;
+  private static final Color STROKE_COLOR = Color.BLACK;
+  private static final Color OWNER_FILL = Color.WHITE;
+
+  private final Polygon shape;
+  private final Color baseColor;
+
+  public TerritoryNode(Territory territory, Color baseColor,
+      double cx, double cy, double radius, String msgKey) {
+    this.baseColor = baseColor;
+    this.shape = buildHexagon(cx, cy, radius);
+    shape.setFill(baseColor);
+    shape.setStroke(STROKE_COLOR);
+    shape.setStrokeWidth(STROKE_WIDTH);
+    shape.setCursor(Cursor.HAND);
+    Tooltip.install(shape, new Tooltip(Messages.get(msgKey)));
+    shape.setOnMouseEntered(e -> shape.setFill(baseColor.brighter()));
+    shape.setOnMouseExited(e -> shape.setFill(baseColor));
+    shape.setOnMouseClicked(e -> {});
+    getChildren().addAll(shape,
+        new Text(cx + LABEL_DX, cy + LABEL_DY, String.valueOf(territory.getTroopCount())),
+        buildOwnerMarker(cx + radius * OWNER_OFFSET, cy - radius * OWNER_OFFSET, territory));
+  }
+
+  private static Circle buildOwnerMarker(double mx, double my, Territory territory) {
+    Circle marker = new Circle(mx, my, OWNER_RADIUS);
+    marker.setFill(OWNER_FILL);
+    marker.setStroke(STROKE_COLOR);
+    marker.setVisible(territory.getOwner() != null);
+    return marker;
+  }
+
+  private static Polygon buildHexagon(double cx, double cy, double radius) {
+    Polygon hex = new Polygon();
+    for (int i = 0; i < HEX_SIDES; i++) {
+      double angle = Math.PI / 3.0 * i;
+      hex.getPoints().add(cx + radius * Math.cos(angle));
+      hex.getPoints().add(cy + radius * Math.sin(angle));
+    }
+    return hex;
+  }
+}

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1,0 +1,66 @@
+# Territory display names (stable internal key -> locale-specific label)
+# Moon Tribe faction
+territory.northernTundra=Northern Tundra
+territory.frostHills=Frost Hills
+territory.moonTribe=Moon Tribe
+territory.binEr=Bin-Er
+territory.yueBay=Yue Bay
+territory.wulong=Wulong
+territory.westernAirTemple=Western Air Temple
+
+# Ba Sing Se Kingdom faction
+territory.zigan=Zigan
+territory.northernAirTemple=Northern Air Temple
+territory.northernMountains=Northern Mountains
+territory.taihua=Taihua
+territory.baSingSeCity=Ba Sing Se City
+territory.baSingSeProvince=Ba Sing Se Province
+territory.continentalCorridor=Continental Corridor
+territory.taku=Taku
+territory.greenFarmlands=Green Farmlands
+territory.charmeleonProvince=Charmeleon Province
+
+# Fire Nation faction
+territory.sunIsles=Sun Isles
+territory.burningGates=Burning Gates
+territory.calderaCity=Caldera City
+territory.blackCliffs=Black Cliffs
+territory.keonso=Keonso
+territory.fireArchipelago=Fire Archipelago
+territory.whaleTailIsle=Whale Tail Isle
+
+# Omashu Kingdom faction
+territory.heiBei=Hei Bei
+territory.greatDivide=Great Divide
+territory.serpentPass=Serpent Pass
+territory.fullMoonBay=Full Moon Bay
+territory.omashu=Omashu
+territory.westernSiWongDesert=Western Si Wong Desert
+territory.easternSiWongDesert=Eastern Si Wong Desert
+territory.heartFarmlands=Heart Farmlands
+territory.chin=Chin
+territory.gaoLing=Gao Ling
+
+# Ocean Tribe faction
+territory.easternAirTemple=Eastern Air Temple
+territory.seafoamIsles=Seafoam Isles
+territory.hakodaIsland=Hakoda Island
+territory.shimsomIsle=Shimsom Isle
+territory.southernAirTemple=Southern Air Temple
+territory.oceanTribe=Ocean Tribe
+territory.southernTundra=Southern Tundra
+territory.icyPlains=Icy Plains
+
+# Faction display names
+faction.moonTribe=Moon Tribe
+faction.baSingSeKingdom=Ba Sing Se Kingdom
+faction.fireNation=Fire Nation
+faction.omashuKingdom=Omashu Kingdom
+faction.oceanTribe=Ocean Tribe
+
+# Faction emblem labels
+faction.moonTribe.emblem=Moon
+faction.baSingSeKingdom.emblem=Ba Sing Se coin
+faction.fireNation.emblem=Fire flame
+faction.omashuKingdom.emblem=Omashu pyramid
+faction.oceanTribe.emblem=Ocean waves

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -67,6 +67,13 @@ public class AtlaMapDataTests {
     assertEquals(8, countByNames(names));
   }
 
+  @Test
+  public void buildMap_allTerritoriesUnowned_getOwnerReturnsNull() {
+    for (Territory territory : gameMap.getTerritories()) {
+      assertNull(territory.getOwner(), "Expected unowned: " + territory.getName());
+    }
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -33,6 +33,15 @@ public class AtlaMapDataTests {
     assertEquals(7, countByNames(names));
   }
 
+  @Test
+  public void buildMap_baSingSeFactionCount_returns10() {
+    List<String> names = Arrays.asList(
+        "Zigan", "Northern Air Temple", "Northern Mountains", "Taihua",
+        "Ba Sing Se City", "Ba Sing Se Province", "Continental Corridor",
+        "Taku", "Green Farmlands", "Charmeleon Province");
+    assertEquals(10, countByNames(names));
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -136,6 +136,21 @@ public class AtlaMapDataTests {
     assertBothDirections("Fire Archipelago", "Whale Tail Isle");
   }
 
+  @Test
+  public void buildMap_omashuKingdomAdjacencies_allEdgesPresentAndSymmetric() {
+    assertBothDirections("Hei Bei", "Great Divide");
+    assertBothDirections("Great Divide", "Serpent Pass");
+    assertBothDirections("Serpent Pass", "Full Moon Bay");
+    assertBothDirections("Full Moon Bay", "Omashu");
+    assertBothDirections("Omashu", "Western Si Wong Desert");
+    assertBothDirections("Omashu", "Eastern Si Wong Desert");
+    assertBothDirections("Western Si Wong Desert", "Heart Farmlands");
+    assertBothDirections("Eastern Si Wong Desert", "Heart Farmlands");
+    assertBothDirections("Heart Farmlands", "Chin");
+    assertBothDirections("Chin", "Gao Ling");
+    assertBothDirections("Gao Ling", "Hei Bei");
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -151,6 +151,18 @@ public class AtlaMapDataTests {
     assertBothDirections("Gao Ling", "Hei Bei");
   }
 
+  @Test
+  public void buildMap_oceanTribeAdjacencies_allEdgesPresentAndSymmetric() {
+    assertBothDirections("Eastern Air Temple", "Seafoam Isles");
+    assertBothDirections("Seafoam Isles", "Hakoda Island");
+    assertBothDirections("Hakoda Island", "Shimsom Isle");
+    assertBothDirections("Shimsom Isle", "Southern Air Temple");
+    assertBothDirections("Southern Air Temple", "Ocean Tribe");
+    assertBothDirections("Ocean Tribe", "Southern Tundra");
+    assertBothDirections("Southern Tundra", "Icy Plains");
+    assertBothDirections("Icy Plains", "Eastern Air Temple");
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -163,6 +163,27 @@ public class AtlaMapDataTests {
     assertBothDirections("Icy Plains", "Eastern Air Temple");
   }
 
+  @Test
+  public void buildMap_whaleTailIsleShimsomIsle_adjacentAndSymmetric() {
+    assertBothDirections("Whale Tail Isle", "Shimsom Isle");
+  }
+
+  @Test
+  public void buildMap_binErYueBayToZigan_adjacentAndSymmetric() {
+    assertBothDirections("Bin-Er", "Zigan");
+    assertBothDirections("Yue Bay", "Zigan");
+  }
+
+  @Test
+  public void buildMap_gaoLingToSeafoamIsles_adjacentAndSymmetric() {
+    assertBothDirections("Gao Ling", "Seafoam Isles");
+  }
+
+  @Test
+  public void buildMap_hakodaIslandToChin_adjacentAndSymmetric() {
+    assertBothDirections("Hakoda Island", "Chin");
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -42,6 +42,31 @@ public class AtlaMapDataTests {
     assertEquals(10, countByNames(names));
   }
 
+  @Test
+  public void buildMap_fireNationFactionCount_returns7() {
+    List<String> names = Arrays.asList(
+        "Sun Isles", "Burning Gates", "Caldera City", "Black Cliffs",
+        "Keonso", "Fire Archipelago", "Whale Tail Isle");
+    assertEquals(7, countByNames(names));
+  }
+
+  @Test
+  public void buildMap_omashuKingdomFactionCount_returns10() {
+    List<String> names = Arrays.asList(
+        "Hei Bei", "Great Divide", "Serpent Pass", "Full Moon Bay",
+        "Omashu", "Western Si Wong Desert", "Eastern Si Wong Desert",
+        "Heart Farmlands", "Chin", "Gao Ling");
+    assertEquals(10, countByNames(names));
+  }
+
+  @Test
+  public void buildMap_oceanTribeFactionCount_returns8() {
+    List<String> names = Arrays.asList(
+        "Eastern Air Temple", "Seafoam Isles", "Hakoda Island", "Shimsom Isle",
+        "Southern Air Temple", "Ocean Tribe", "Southern Tundra", "Icy Plains");
+    assertEquals(8, countByNames(names));
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -110,6 +110,21 @@ public class AtlaMapDataTests {
     assertBothDirections("Wulong", "Western Air Temple");
   }
 
+  @Test
+  public void buildMap_baSingSeKingdomAdjacencies_allEdgesPresentAndSymmetric() {
+    assertBothDirections("Zigan", "Northern Air Temple");
+    assertBothDirections("Zigan", "Northern Mountains");
+    assertBothDirections("Northern Air Temple", "Northern Mountains");
+    assertBothDirections("Northern Mountains", "Taihua");
+    assertBothDirections("Taihua", "Ba Sing Se City");
+    assertBothDirections("Ba Sing Se City", "Ba Sing Se Province");
+    assertBothDirections("Ba Sing Se Province", "Continental Corridor");
+    assertBothDirections("Continental Corridor", "Taku");
+    assertBothDirections("Taku", "Green Farmlands");
+    assertBothDirections("Green Farmlands", "Charmeleon Province");
+    assertBothDirections("Charmeleon Province", "Ba Sing Se Province");
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -25,6 +25,14 @@ public class AtlaMapDataTests {
     assertEquals(42, gameMap.getTerritories().size());
   }
 
+  @Test
+  public void buildMap_moonTribeFactionCount_returns7() {
+    List<String> names = Arrays.asList(
+        "Northern Tundra", "Frost Hills", "Moon Tribe", "Bin-Er",
+        "Yue Bay", "Wulong", "Western Air Temple");
+    assertEquals(7, countByNames(names));
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -74,6 +74,14 @@ public class AtlaMapDataTests {
     }
   }
 
+  @Test
+  public void buildMap_allTerritoriesZeroTroops_getTroopCountReturnsZero() {
+    for (Territory territory : gameMap.getTerritories()) {
+      assertEquals(0, territory.getTroopCount(),
+          "Expected 0 troops: " + territory.getName());
+    }
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -82,6 +82,23 @@ public class AtlaMapDataTests {
     }
   }
 
+  @Test
+  public void buildMap_noSelfLoops_noTerritoryAdjacentToItself() {
+    for (Territory territory : gameMap.getTerritories()) {
+      assertFalse(gameMap.getNeighbors(territory).contains(territory),
+          "Self-loop: " + territory.getName());
+    }
+  }
+
+  @Test
+  public void buildMap_noDuplicateEdges_neighborListHasNoDuplicates() {
+    for (Territory territory : gameMap.getTerritories()) {
+      List<Territory> neighbors = gameMap.getNeighbors(territory);
+      assertEquals(new HashSet<>(neighbors).size(), neighbors.size(),
+          "Duplicate neighbor for: " + territory.getName());
+    }
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -99,6 +99,17 @@ public class AtlaMapDataTests {
     }
   }
 
+  @Test
+  public void buildMap_moonTribeAdjacencies_allEdgesPresentAndSymmetric() {
+    assertBothDirections("Northern Tundra", "Frost Hills");
+    assertBothDirections("Northern Tundra", "Moon Tribe");
+    assertBothDirections("Frost Hills", "Bin-Er");
+    assertBothDirections("Moon Tribe", "Bin-Er");
+    assertBothDirections("Bin-Er", "Yue Bay");
+    assertBothDirections("Yue Bay", "Wulong");
+    assertBothDirections("Wulong", "Western Air Temple");
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -184,6 +184,11 @@ public class AtlaMapDataTests {
     assertBothDirections("Hakoda Island", "Chin");
   }
 
+  @Test
+  public void continentCount_factionStructure_returns5() {
+    assertEquals(5, new AtlaMapData().continentCount());
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -125,6 +125,17 @@ public class AtlaMapDataTests {
     assertBothDirections("Charmeleon Province", "Ba Sing Se Province");
   }
 
+  @Test
+  public void buildMap_fireNationAdjacencies_allEdgesPresentAndSymmetric() {
+    assertBothDirections("Sun Isles", "Burning Gates");
+    assertBothDirections("Sun Isles", "Caldera City");
+    assertBothDirections("Burning Gates", "Caldera City");
+    assertBothDirections("Caldera City", "Black Cliffs");
+    assertBothDirections("Black Cliffs", "Keonso");
+    assertBothDirections("Keonso", "Fire Archipelago");
+    assertBothDirections("Fire Archipelago", "Whale Tail Isle");
+  }
+
   // --- helpers ---
 
   private long countByNames(List<String> names) {

--- a/src/test/java/domain/AtlaMapDataTests.java
+++ b/src/test/java/domain/AtlaMapDataTests.java
@@ -1,0 +1,49 @@
+package domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AtlaMapDataTests {
+
+  private GameMap gameMap;
+
+  @BeforeEach
+  public void setUp() {
+    gameMap = new AtlaMapData().buildMap();
+  }
+
+  @Test
+  public void buildMap_totalTerritoryCount_returns42() {
+    assertEquals(42, gameMap.getTerritories().size());
+  }
+
+  // --- helpers ---
+
+  private long countByNames(List<String> names) {
+    return gameMap.getTerritories().stream()
+        .filter(t -> names.contains(t.getName()))
+        .count();
+  }
+
+  private Territory findByName(String name) {
+    return gameMap.getTerritories().stream()
+        .filter(t -> t.getName().equals(name))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Territory not found: " + name));
+  }
+
+  private void assertBothDirections(String nameA, String nameB) {
+    Territory ta = findByName(nameA);
+    Territory tb = findByName(nameB);
+    assertTrue(gameMap.areAdjacent(ta, tb), nameA + " -> " + nameB);
+    assertTrue(gameMap.areAdjacent(tb, ta), nameB + " -> " + nameA);
+  }
+}

--- a/src/test/java/domain/TerritoryTests.java
+++ b/src/test/java/domain/TerritoryTests.java
@@ -20,6 +20,14 @@ public class TerritoryTests {
   }
 
   @Test
+  public void constructor_unownedValidName_nameStoredOwnerNullTroopsZero() {
+    Territory territory = new Territory("TestTerritory");
+    assertEquals("TestTerritory", territory.getName());
+    assertNull(territory.getOwner());
+    assertEquals(0, territory.getTroopCount());
+  }
+
+  @Test
   public void constructor_nullName_throwsIllegalArgumentException() {
     Player p1 = EasyMock.createMock(Player.class);
     assertThrows(IllegalArgumentException.class, () -> new Territory(null, p1, 5));

--- a/src/test/java/domain/TerritoryTests.java
+++ b/src/test/java/domain/TerritoryTests.java
@@ -15,6 +15,11 @@ public class TerritoryTests {
   }
 
   @Test
+  public void constructor_unownedEmptyName_throwsIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> new Territory(""));
+  }
+
+  @Test
   public void constructor_nullName_throwsIllegalArgumentException() {
     Player p1 = EasyMock.createMock(Player.class);
     assertThrows(IllegalArgumentException.class, () -> new Territory(null, p1, 5));

--- a/src/test/java/domain/TerritoryTests.java
+++ b/src/test/java/domain/TerritoryTests.java
@@ -1,12 +1,18 @@
 package domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 
 public class TerritoryTests {
+
+  @Test
+  public void constructor_unownedNullName_throwsIllegalArgumentException() {
+    assertThrows(IllegalArgumentException.class, () -> new Territory(null));
+  }
 
   @Test
   public void constructor_nullName_throwsIllegalArgumentException() {


### PR DESCRIPTION
## Description

Builds the ATLA-themed game-setup GUI on top of the completed domain layer. Adds the JavaFX map view rendering all 42 territories from `AtlaMapData.buildMap()`, grouped by faction with distinct colors, clickable nodes, hover-highlights, localized tooltips, ownership markers, and troop-count labels. Also adds the i18n infrastructure (`Messages` helper + `messages.properties` with 52 keys) and wires `ui.Main` to launch the map in a pannable `ScrollPane`. No domain classes were modified.

Run `./gradlew run` for verification.

## Related Task

Closes [Task #30](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/30).

---

## ✅ PR Checklist

### 🧪 Testing

- [x] All existing automated tests pass
- [x] New code is covered by tests written **before** the implementation (TDD/BDD)
- [x] Test inputs and assertions are based on BVA analysis
- [x] Mutation testing has been run — **100% of non-equivalent mutants are killed**
- [x] **100% cyclomatic coverage** for all non-GUI and non-enum code
- [x] Integration tests updated/added if this PR touches a main feature (at least 2 main features must have integration
  tests by end of project)

### 🎨 Code Quality

- [x] Code fully satisfies the team's agreed style standards
- [x] Code follows **Clean Code** principles (meaningful names, small functions, no dead code, etc.)
- [x] No unnecessary comments and minimal TODOs left in

### 🌍 Localization (i18n)

- [x] Any new user-facing strings are externalized (not hardcoded)
- [x] Adding this change does not require modifying existing locale files to support a new language

### 🔁 Process

- [x] The corresponding task on the project management board is updated with a **detailed description**
- [x] This week's planning/progress notes are up to date in the team's documentation
- [x] This PR targets the correct branch and is **not** a direct push to `main`
- [x] CI pipeline passes ✅

---

## 📸 Screenshots / Evidence (if applicable)

<img width="1091" height="776" alt="Screenshot 2026-05-26 at 3 59 15 PM" src="https://github.com/user-attachments/assets/edb4a3bb-f71c-4860-9c34-dab1371c7b21" />

<img width="1149" height="436" alt="Screenshot 2026-05-26 at 4 03 01 PM" src="https://github.com/user-attachments/assets/98cc4082-e16d-4773-9a71-c1d8da41d601" />

<img width="1149" height="465" alt="Screenshot 2026-05-26 at 4 03 31 PM" src="https://github.com/user-attachments/assets/65edf2b3-0686-458a-a448-5e34cfd9ce2d" />

<img width="887" height="245" alt="Screenshot 2026-05-26 at 4 05 48 PM" src="https://github.com/user-attachments/assets/dea12fb1-f5f0-4cd8-baa2-5c2311ffbde0" />

<img width="1173" height="271" alt="Screenshot 2026-05-26 at 4 06 01 PM" src="https://github.com/user-attachments/assets/6ba93bf4-5e17-4378-9ebc-03d367003dfb" />

<img width="1331" height="267" alt="Screenshot 2026-05-26 at 4 06 18 PM" src="https://github.com/user-attachments/assets/8caef22d-3072-4fa7-bf87-f6061e8995c8" />

closes #60 closes #76
