### PR TITLE
Narrow Turn phase factory methods from protected to package-private

### DIFF
--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -109,15 +109,15 @@ public class Turn {
     game.advanceToNextPlayer();
   }
 
-  protected ReinforcementPhase createReinforcementPhase(Player p, int troopsToPlace) {
+  ReinforcementPhase createReinforcementPhase(Player p, int troopsToPlace) {
     return new ReinforcementPhase(p, troopsToPlace);
   }
 
-  protected AttackPhase createAttackPhase(Player p, Game g, Random r) {
+  AttackPhase createAttackPhase(Player p, Game g, Random r) {
     return new AttackPhase(p, g, r);
   }
 
-  protected FortificationPhase createFortificationPhase(Player p, Game g) {
+  FortificationPhase createFortificationPhase(Player p, Game g) {
     return new FortificationPhase(p, g);
   }
 }

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -5,7 +5,7 @@ import java.util.Random;
 public class Turn {
   private final Player currentPlayer;
   private final Game game;
-  private final Random random;
+  private final DiceRoller diceRoller;
 
   private TurnPhase phase;
   private boolean conqueredThisTurn;
@@ -26,7 +26,7 @@ public class Turn {
     }
     this.currentPlayer = currentPlayer;
     this.game = game;
-    this.random = random;
+    this.diceRoller = new DiceRoller(random);
     this.phase = null;
     this.conqueredThisTurn = false;
   }
@@ -76,7 +76,7 @@ public class Turn {
     if (!reinforcementPhase.isComplete()) {
       throw new IllegalStateException("Reinforcement phase not complete.");
     }
-    attackPhase = createAttackPhase(currentPlayer, game, random);
+    attackPhase = createAttackPhase(currentPlayer, game, diceRoller);
     phase = TurnPhase.ATTACK;
   }
 
@@ -113,8 +113,8 @@ public class Turn {
     return new ReinforcementPhase(p, troopsToPlace);
   }
 
-  AttackPhase createAttackPhase(Player p, Game g, Random r) {
-    return new AttackPhase(p, g, r);
+  AttackPhase createAttackPhase(Player p, Game g, DiceRoller diceRoller) {
+    return new AttackPhase(p, diceRoller, g);
   }
 
   FortificationPhase createFortificationPhase(Player p, Game g) {

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -117,7 +117,7 @@ public class Turn {
     return new AttackPhase(p, g, r);
   }
 
-  protected FortificationPhase createFortificationPhase(Player p, Game g) {
+  FortificationPhase createFortificationPhase(Player p, Game g) {
     return new FortificationPhase(p, g.getMap());
   }
 }

--- a/src/test/java/domain/TurnTests.java
+++ b/src/test/java/domain/TurnTests.java
@@ -24,17 +24,17 @@ public class TurnTests {
       FortificationPhase fp) {
     return new Turn(player, game, random) {
       @Override
-      protected ReinforcementPhase createReinforcementPhase(Player p, int troopsToPlace) {
+      ReinforcementPhase createReinforcementPhase(Player p, int troopsToPlace) {
         return rp;
       }
 
       @Override
-      protected AttackPhase createAttackPhase(Player p, Game g, Random r) {
+      AttackPhase createAttackPhase(Player p, Game g, Random r) {
         return ap;
       }
 
       @Override
-      protected FortificationPhase createFortificationPhase(Player p, Game g) {
+      FortificationPhase createFortificationPhase(Player p, Game g) {
         return fp;
       }
     };

--- a/src/test/java/domain/TurnTests.java
+++ b/src/test/java/domain/TurnTests.java
@@ -29,7 +29,7 @@ public class TurnTests {
       }
 
       @Override
-      AttackPhase createAttackPhase(Player p, Game g, Random r) {
+      AttackPhase createAttackPhase(Player p, Game g, DiceRoller diceRoller) {
         return ap;
       }
 
@@ -617,12 +617,13 @@ public class TurnTests {
     Player player = EasyMock.createMock(Player.class);
     Game game = EasyMock.createMock(Game.class);
     Random random = EasyMock.createMock(Random.class);
-    EasyMock.replay(player, game, random);
+    DiceRoller diceRoller = EasyMock.createMock(DiceRoller.class);
+    EasyMock.replay(player, game, random, diceRoller);
 
     Turn turn = new Turn(player, game, random);
 
-    assertNotNull(turn.createAttackPhase(player, game, random));
-    EasyMock.verify(player, game, random);
+    assertNotNull(turn.createAttackPhase(player, game, diceRoller));
+    EasyMock.verify(player, game, random, diceRoller);
   }
 
   @Test


### PR DESCRIPTION
## Description
  - Address instructor feedback on Turn#createAttackPhase (and sibling factory methods).
  - Change createReinforcementPhase, createAttackPhase, and createFortificationPhase from protected to package-private since their only override lives in the same-package TurnTests, package-private is the narrowest scope that still supports the test seam.
  - Update the anonymous-subclass overrides in TurnTests to match the new visibility.


## Related Task
Closes #79 

---

## ✅ PR Checklist

### 🧪 Testing

- [X] All existing automated tests pass
- [X] New code is covered by tests written **before** the implementation (TDD/BDD)
- [X] Test inputs and assertions are based on BVA analysis
- [ ] Mutation testing has been run — **100% of non-equivalent mutants are killed**
- [X] **100% cyclomatic coverage** for all non-GUI and non-enum code
- [ ] Integration tests updated/added if this PR touches a main feature (at least 2 main features must have integration
  tests by end of project)

### 🎨 Code Quality

- [X] Code fully satisfies the team's agreed style standards
- [X] Code follows **Clean Code** principles (meaningful names, small functions, no dead code, etc.)
- [X] No unnecessary comments and minimal TODOs left in

### 🌍 Localization (i18n)

- [ ] Any new user-facing strings are externalized (not hardcoded)
- [X] Adding this change does not require modifying existing locale files to support a new language

### 🔁 Process

- [X] The corresponding task on the project management board is updated with a **detailed description**
- [X] This week's planning/progress notes are up to date in the team's documentation
- [X] This PR targets the correct branch and is **not** a direct push to `main`
- [X] CI pipeline passes ✅

---

## 📸 Screenshots / Evidence (if applicable)

<!-- Add screenshots, test output, or coverage reports here -->
