### PR TITLE
Wire SpotBugs into the build with strict mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ repositories {
 }
 
 dependencies {
+    compileOnly("com.github.spotbugs:spotbugs-annotations:4.8.6")
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.easymock:easymock:5.4.0")
@@ -86,6 +87,7 @@ spotbugs {
     effort.set(com.github.spotbugs.snom.Effort.MAX)
     reportLevel.set(com.github.spotbugs.snom.Confidence.LOW)
     ignoreFailures.set(false)
+    excludeFilter.set(file("config/spotbugs/exclude.xml"))
 }
 
 tasks.withType<com.github.spotbugs.snom.SpotBugsTask>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("jacoco")
     id("info.solidsoft.pitest") version "1.15.0"
     id("org.openjfx.javafxplugin") version "0.1.0"
+    id("com.github.spotbugs") version "6.0.26"
 }
 
 group = "nu.csse.sqe"
@@ -78,4 +79,15 @@ tasks.jacocoTestReport {
         csv.required.set(false)
         html.outputLocation = layout.buildDirectory.dir("reports/jacoco")
     }
+}
+
+spotbugs {
+    toolVersion.set("4.8.6")
+    effort.set(com.github.spotbugs.snom.Effort.MAX)
+    reportLevel.set(com.github.spotbugs.snom.Confidence.LOW)
+    ignoreFailures.set(false)
+}
+
+tasks.withType<com.github.spotbugs.snom.SpotBugsTask>().configureEach {
+    reports.create("html") { required.set(true) }
 }

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+  <!-- TODO: remove when Jefferson implements player-elimination logic. -->
+  <Match>
+    <Class name="domain.Player"/>
+    <Field name="isEliminated"/>
+    <Bug pattern="UWF_UNWRITTEN_FIELD"/>
+  </Match>
+
+  <!-- TODO: remove when Kris wires up hover/reset behavior using baseColor. -->
+  <Match>
+    <Class name="ui.TerritoryNode"/>
+    <Field name="baseColor"/>
+    <Bug pattern="URF_UNREAD_FIELD"/>
+  </Match>
+
+  <!-- Test seam: the anonymous Turn subclass in buildTurn captures enclosing 'this' to
+       reach the rp/ap/fp helper parameters. Refactoring to a named static inner class
+       would significantly bloat the test helper for no test-quality benefit. -->
+  <Match>
+    <Class name="~domain\.TurnTests\$.*"/>
+    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
+  </Match>
+
+</FindBugsFilter>

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -22,7 +22,7 @@
        reach the rp/ap/fp helper parameters. Refactoring to a named static inner class
        would significantly bloat the test helper for no test-quality benefit. -->
   <Match>
-    <Class name="~domain\.TurnTests\$.*"/>
+    <Source name="~.*TurnTests\.java"/>
     <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
   </Match>
 

--- a/src/main/java/domain/AttackPhase.java
+++ b/src/main/java/domain/AttackPhase.java
@@ -1,5 +1,6 @@
 package domain;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 
 public class AttackPhase {
@@ -15,6 +16,11 @@ public class AttackPhase {
   private int lastAttackDice = 0;
   private boolean ended = false;
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Player is an aggregate domain object intentionally shared by reference; "
+          + "the phase needs to mutate and read the same Player as the rest of the Turn."
+  )
   public AttackPhase(Player attacker, DiceRoller diceRoller, Game game) {
     this.attacker = attacker;
     this.diceRoller = diceRoller;

--- a/src/main/java/domain/DiceRoller.java
+++ b/src/main/java/domain/DiceRoller.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
-public final class DiceRoller {
+public class DiceRoller {
   private static final int MAX_ATTACKER_DICE = 3;
   private static final int MAX_DEFENDER_DICE = 2;
   private static final int FACES_PER_DIE = 6;
@@ -15,7 +15,8 @@ public final class DiceRoller {
 
   @SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
-      justification = "Random is shared so the test harness can seed it for deterministic rolls."
+      justification = "Random is shared so the test harness can seed it for deterministic rolls. "
+          + "Class is non-final because EasyMock subclasses it to mock in tests."
   )
   public DiceRoller(Random random) {
     this.random = random;

--- a/src/main/java/domain/DiceRoller.java
+++ b/src/main/java/domain/DiceRoller.java
@@ -1,17 +1,22 @@
 package domain;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
-public class DiceRoller {
+public final class DiceRoller {
   private static final int MAX_ATTACKER_DICE = 3;
   private static final int MAX_DEFENDER_DICE = 2;
   private static final int FACES_PER_DIE = 6;
 
   private final Random random;
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Random is shared so the test harness can seed it for deterministic rolls."
+  )
   public DiceRoller(Random random) {
     this.random = random;
   }

--- a/src/main/java/domain/FortificationPhase.java
+++ b/src/main/java/domain/FortificationPhase.java
@@ -1,10 +1,18 @@
 package domain;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class FortificationPhase {
   private final Player player;
   private final GameMap map;
   private boolean moved;
 
+  @SuppressFBWarnings(
+      value = {"EI_EXPOSE_REP2", "CT_CONSTRUCTOR_THROW"},
+      justification = "Player and GameMap are aggregate domain objects intentionally shared by "
+          + "reference; the phase needs to mutate and read the same instances as the rest of the "
+          + "Turn. Class is non-final because EasyMock subclasses it to mock in tests."
+  )
   public FortificationPhase(Player player, GameMap map) {
     if (player == null) {
       throw new IllegalArgumentException("Player cannot be null");

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
-public final class Game {
+public class Game {
   private static final int BASE_STARTING_ARMIES = 50;
   private static final int ARMIES_REDUCTION_PER_PLAYER = 5;
   private static final int MIN_NUMBER_OF_PLAYERS = 2;
@@ -18,10 +18,11 @@ public final class Game {
   private int currentPlayerIndex = -1;
 
   @SuppressFBWarnings(
-      value = "EI_EXPOSE_REP2",
+      value = {"EI_EXPOSE_REP2", "CT_CONSTRUCTOR_THROW"},
       justification = "Random is shared so the test harness can seed it for deterministic shuffling. "
           + "GameMap is the shared aggregate root for the territory graph; cloning it would "
-          + "create orphan territories that drift from real game state."
+          + "create orphan territories that drift from real game state. Class is non-final because "
+          + "EasyMock subclasses it to mock in tests."
   )
   public Game(List<Player> players, GameMap map, List<RiskCard> deck, Random random) {
     validatePlayers(players);

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -19,10 +19,10 @@ public class Game {
 
   @SuppressFBWarnings(
       value = {"EI_EXPOSE_REP2", "CT_CONSTRUCTOR_THROW"},
-      justification = "Random is shared so the test harness can seed it for deterministic shuffling. "
-          + "GameMap is the shared aggregate root for the territory graph; cloning it would "
-          + "create orphan territories that drift from real game state. Class is non-final because "
-          + "EasyMock subclasses it to mock in tests."
+      justification = "Random is shared so the test harness can seed it for deterministic "
+          + "shuffling. GameMap is the shared aggregate root for the territory graph; cloning "
+          + "it would create orphan territories that drift from real game state. Class is "
+          + "non-final because EasyMock subclasses it to mock in tests."
   )
   public Game(List<Player> players, GameMap map, List<RiskCard> deck, Random random) {
     validatePlayers(players);

--- a/src/main/java/domain/Game.java
+++ b/src/main/java/domain/Game.java
@@ -1,11 +1,12 @@
 package domain;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
-public class Game {
+public final class Game {
   private static final int BASE_STARTING_ARMIES = 50;
   private static final int ARMIES_REDUCTION_PER_PLAYER = 5;
   private static final int MIN_NUMBER_OF_PLAYERS = 2;
@@ -16,12 +17,18 @@ public class Game {
   private final Random random;
   private int currentPlayerIndex = -1;
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Random is shared so the test harness can seed it for deterministic shuffling. "
+          + "GameMap is the shared aggregate root for the territory graph; cloning it would "
+          + "create orphan territories that drift from real game state."
+  )
   public Game(List<Player> players, GameMap map, List<RiskCard> deck, Random random) {
     validatePlayers(players);
     validateMap(map);
-    this.players = players;
+    this.players = new ArrayList<>(players);
     this.map = map;
-    this.deck = deck;
+    this.deck = new ArrayList<>(deck);
     this.random = random;
   }
 
@@ -92,6 +99,11 @@ public class Game {
     return players.size();
   }
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "GameMap is the shared aggregate root for the territory graph; "
+          + "callers need the live reference to read game state."
+  )
   public GameMap getMap() {
     return map;
   }

--- a/src/main/java/domain/Player.java
+++ b/src/main/java/domain/Player.java
@@ -1,16 +1,21 @@
 package domain;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public final class Player {
+public class Player {
   private final String name;
   private final List<Territory> territories;
   private final List<RiskCard> cards;
   private int availableTroops;
   private boolean isEliminated;
 
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification = "Class is non-final because EasyMock subclasses it to mock in tests."
+  )
   public Player(String name) {
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException("Player name cannot be null or empty");

--- a/src/main/java/domain/Player.java
+++ b/src/main/java/domain/Player.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class Player {
+public final class Player {
   private final String name;
   private final List<Territory> territories;
   private final List<RiskCard> cards;

--- a/src/main/java/domain/ReinforcementPhase.java
+++ b/src/main/java/domain/ReinforcementPhase.java
@@ -2,7 +2,7 @@ package domain;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public final class ReinforcementPhase {
+public class ReinforcementPhase {
   private final Player player;
   private int troopsToPlace;
 

--- a/src/main/java/domain/ReinforcementPhase.java
+++ b/src/main/java/domain/ReinforcementPhase.java
@@ -1,9 +1,16 @@
 package domain;
 
-public class ReinforcementPhase {
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public final class ReinforcementPhase {
   private final Player player;
   private int troopsToPlace;
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Player is an aggregate domain object intentionally shared by reference; "
+          + "the phase needs to mutate and read the same Player as the rest of the Turn."
+  )
   public ReinforcementPhase(Player player, int troopsToPlace) {
     this.player = player;
     this.troopsToPlace = troopsToPlace;

--- a/src/main/java/domain/RiskCard.java
+++ b/src/main/java/domain/RiskCard.java
@@ -1,9 +1,16 @@
 package domain;
 
-public class RiskCard {
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public final class RiskCard {
   private final RiskCardType riskCardType;
   private final Territory territory;
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Territory is an aggregate domain object intentionally shared by reference; "
+          + "the card identifies an actual board territory, not a copy."
+  )
   public RiskCard(RiskCardType riskCardType, Territory territory) {
     if (riskCardType == null) {
       throw new IllegalArgumentException("Risk Card Type cannot be null");
@@ -19,6 +26,10 @@ public class RiskCard {
     return this.riskCardType;
   }
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "Returns the shared aggregate Territory by design; see ctor justification."
+  )
   public Territory getTerritory() {
     return this.territory;
   }

--- a/src/main/java/domain/RiskCard.java
+++ b/src/main/java/domain/RiskCard.java
@@ -2,14 +2,15 @@ package domain;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public final class RiskCard {
+public class RiskCard {
   private final RiskCardType riskCardType;
   private final Territory territory;
 
   @SuppressFBWarnings(
-      value = "EI_EXPOSE_REP2",
+      value = {"EI_EXPOSE_REP2", "CT_CONSTRUCTOR_THROW"},
       justification = "Territory is an aggregate domain object intentionally shared by reference; "
-          + "the card identifies an actual board territory, not a copy."
+          + "the card identifies an actual board territory, not a copy. "
+          + "Class is non-final because EasyMock subclasses it to mock in tests."
   )
   public RiskCard(RiskCardType riskCardType, Territory territory) {
     if (riskCardType == null) {

--- a/src/main/java/domain/Territory.java
+++ b/src/main/java/domain/Territory.java
@@ -1,6 +1,8 @@
 package domain;
 
-public class Territory {
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+public final class Territory {
   private final String name;
   private Player owner;
   private int troopCount;
@@ -14,6 +16,10 @@ public class Territory {
     this.troopCount = 0;
   }
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Player is an aggregate domain object intentionally shared by reference."
+  )
   public Territory(String name, Player owner, int troopCount) {
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException("Territory name cannot be null or empty.");
@@ -48,14 +54,26 @@ public class Territory {
     return this.troopCount;
   }
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "Returns the shared aggregate Player by design."
+  )
   public Player getOwner() {
     return this.owner;
   }
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Player is an aggregate domain object intentionally shared by reference."
+  )
   public void setOwner(Player owner) {
     this.owner = owner;
   }
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification = "Player is an aggregate domain object intentionally shared by reference."
+  )
   public void conquer(Player newOwner, int troopsMovedIn) {
     if (troopsMovedIn == 0) {
       throw new IllegalArgumentException("Conquered Territories must have at least 1 troop");

--- a/src/main/java/domain/Territory.java
+++ b/src/main/java/domain/Territory.java
@@ -2,11 +2,15 @@ package domain;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-public final class Territory {
+public class Territory {
   private final String name;
   private Player owner;
   private int troopCount;
 
+  @SuppressFBWarnings(
+      value = "CT_CONSTRUCTOR_THROW",
+      justification = "Class is non-final because EasyMock subclasses it to mock in tests."
+  )
   public Territory(String name) {
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException("Territory name cannot be null or empty.");
@@ -17,8 +21,9 @@ public final class Territory {
   }
 
   @SuppressFBWarnings(
-      value = "EI_EXPOSE_REP2",
-      justification = "Player is an aggregate domain object intentionally shared by reference."
+      value = {"EI_EXPOSE_REP2", "CT_CONSTRUCTOR_THROW"},
+      justification = "Player is an aggregate domain object intentionally shared by reference. "
+          + "Class is non-final because EasyMock subclasses it to mock in tests."
   )
   public Territory(String name, Player owner, int troopCount) {
     if (name == null || name.isEmpty()) {

--- a/src/main/java/domain/Turn.java
+++ b/src/main/java/domain/Turn.java
@@ -1,5 +1,6 @@
 package domain;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Random;
 
 public class Turn {
@@ -14,6 +15,12 @@ public class Turn {
   private AttackPhase attackPhase;
   private FortificationPhase fortificationPhase;
 
+  @SuppressFBWarnings(
+      value = {"EI_EXPOSE_REP2", "CT_CONSTRUCTOR_THROW"},
+      justification = "Player/Game are aggregate domain objects intentionally shared by reference; "
+          + "Random is shared for deterministic test seeding. Class is intentionally non-final "
+          + "to allow TurnTests to subclass it as a test seam for the createXxxPhase factories."
+  )
   public Turn(Player currentPlayer, Game game, Random random) {
     if (currentPlayer == null) {
       throw new IllegalArgumentException("currentPlayer cannot be null.");
@@ -29,12 +36,19 @@ public class Turn {
     this.random = random;
     this.phase = null;
     this.conqueredThisTurn = false;
+    this.reinforcementPhase = null;
+    this.attackPhase = null;
+    this.fortificationPhase = null;
   }
 
   public TurnPhase getPhase() {
     return phase;
   }
 
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP",
+      justification = "Returns the shared aggregate Player by design."
+  )
   public Player getCurrentPlayer() {
     return currentPlayer;
   }

--- a/src/main/java/ui/MapView.java
+++ b/src/main/java/ui/MapView.java
@@ -12,7 +12,7 @@ import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Line;
 
-public class MapView extends Pane {
+public final class MapView extends Pane {
 
   private static final double MAP_WIDTH = 1100.0;
   private static final double MAP_HEIGHT = 750.0;

--- a/src/main/java/ui/TerritoryNode.java
+++ b/src/main/java/ui/TerritoryNode.java
@@ -10,7 +10,7 @@ import javafx.scene.shape.Circle;
 import javafx.scene.shape.Polygon;
 import javafx.scene.text.Text;
 
-public class TerritoryNode extends Group {
+public final class TerritoryNode extends Group {
 
   private static final double STROKE_WIDTH = 1.5;
   private static final double OWNER_RADIUS = 8.0;


### PR DESCRIPTION
 - Adds com.github.spotbugs plugin (strict: effort=MAX, reportLevel=LOW, ignoreFailures=false); runs as part of ./gradlew check.
  - Fixes or documents every SpotBugs warning across main + test. Build is green.
  - Defensive copies in Game ctor for players and deck.
  - Per-field/method @SuppressFBWarnings with justification strings where defensive copying is impossible (Random) or would break the design (shared aggregate refs: Player, Territory, GameMap). Covers Game,
  Player, RiskCard, Territory, Turn, DiceRoller, ReinforcementPhase, AttackPhase, FortificationPhase.
  - final class on MapView and TerritoryNode (no subclasses, no mocks). All domain.* classes stay non-final, EasyMock subclasses them in tests, and use @SuppressFBWarnings("CT_CONSTRUCTOR_THROW") with that
  reason noted.
  - Turn lazy-init: explicit = null on the three phase fields in the constructor to silence UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR.

`config/spotbugs/exclude.xml`; 3 documented suppressions

  1. domain.Player.isEliminated (UWF_UNWRITTEN_FIELD): TODO. Field is read but never written; no player-elimination logic in the game yet. Jefferson is implementing this in a follow-up PR; he should delete this
   entry as part of that work.
  2. ui.TerritoryNode.baseColor (URF_UNREAD_FIELD): TODO. Field is shadowed by the ctor parameter, so the write is dead. Kris is wiring up hover/reset behavior using baseColor in a follow-up PR; he should 
  delete this entry as part of that work.
  3. domain.TurnTests (SIC_INNER_SHOULD_BE_STATIC_ANON): the anonymous Turn subclass in buildTurn(...) captures the enclosing instance. Refactoring would bloat the test helper for no benefit.

## Related Task
Closes #80 

---

## ✅ PR Checklist

### 🧪 Testing

- [X] All existing automated tests pass
- [X] New code is covered by tests written **before** the implementation (TDD/BDD)
- [X] Test inputs and assertions are based on BVA analysis
- [X] Mutation testing has been run — **100% of non-equivalent mutants are killed**
- [X] **100% cyclomatic coverage** for all non-GUI and non-enum code
- [ ] Integration tests updated/added if this PR touches a main feature (at least 2 main features must have integration
  tests by end of project)

### 🎨 Code Quality

- [X] Code fully satisfies the team's agreed style standards
- [X] Code follows **Clean Code** principles (meaningful names, small functions, no dead code, etc.)
- [ ] No unnecessary comments and minimal TODOs left in

### 🌍 Localization (i18n)

- [ ] Any new user-facing strings are externalized (not hardcoded)
- [X] Adding this change does not require modifying existing locale files to support a new language

### 🔁 Process

- [X] The corresponding task on the project management board is updated with a **detailed description**
- [X] This week's planning/progress notes are up to date in the team's documentation
- [X] This PR targets the correct branch and is **not** a direct push to `main`
- [X] CI pipeline passes ✅

---

## 📸 Screenshots / Evidence (if applicable)

<!-- Add screenshots, test output, or coverage reports here -->
