### PR TITLE
Add F6 (Attack) integration test + feature index

### DIFF
--- a/docs/requirements/features.md
+++ b/docs/requirements/features.md
@@ -1,0 +1,38 @@
+# System Features (Integration Testing Index)
+
+This file indexes the system features used for **integration (thread) testing**, per the
+course's recommended approach: integrate modules along a *thread of execution* that
+corresponds to a system feature, and write one test class per feature
+(`F1Tests.java`, `F2Tests.java`, ...).
+
+We use **TDD / JUnit thread tests** (the rubric accepts TDD *or* BDD equivalently). Each
+feature test wires **real collaborators together with no mocks** — this is what
+distinguishes an integration test from the per-class unit tests in `src/test/java/domain`,
+which isolate a single class with EasyMock.
+
+For an **A**, the rubric requires "integration testing is done on at least 2 main features."
+We only need integration coverage on 2+ features, not all of them; the full list is
+documented here for shared reference and to make clear to the grader which features are
+covered.
+
+| ID  | Feature | Primary collaborators | Integration test |
+|-----|---------|-----------------------|------------------|
+| F1  | Display the game map (territories, continents, borders) | `GameMap`, `Territory`, `MapView` (GUI) | — (GUI, excluded) |
+| F2  | Create players with starting territories and armies | `Game`, `Player`, `Territory`, `GameMap`, `SetupPhase` | — |
+| F3  | Place armies according to per-turn rules | `ReinforcementPhase`, `Player`, `Territory` | — |
+| F4  | Count turns / turn-based gameplay loop | `GameLoop`, `Turn`, `Game`, `Player` | — |
+| F5  | Receive & place reinforcements (territory + continent bonuses) | `ReinforcementPhase`, `Player`, `Territory`, `Game` | — |
+| F6  | Attack enemy territories with dice mechanics | `AttackPhase`, `DiceRoller`, `BattleResult`, `Territory`, `Player`, `GameMap`, `Game`, `DeckManager` | ✅ `F6Tests.java` |
+| F7  | Fortify: move armies between owned territories | `FortificationPhase`, `GameMap`, `Player`, `Territory`, `ConnectivityGraph` | _planned next_ |
+| F8  | Earn a card for a successful attack (one per turn) | `AttackPhase`, `Game`, `DeckManager`, `RiskCard`, `Player` | partially via F6 |
+| F9  | Trade cards for reinforcements | `CardTradePhase`, `CardTradeValidator`, `Player`, `RiskCard` | — (impl in progress) |
+| F10 | Detect win (capture all territories / eliminate all players) | `GameLoop`, `Game`, `Player` | — |
+
+## Status
+
+- **F6 (Attack)** — covered by `src/test/java/domain/F6Tests.java`. Exercises the full attack
+  thread end to end: adjacency validation through `GameMap`, dice resolution through the real
+  `DiceRoller`/`BattleResult`, troop attrition and ownership transfer across `Territory`/`Player`,
+  and the card award through `Game`/`DeckManager`.
+- **Second feature (planned):** F7 (Fortify) or F5 (Reinforcement) — both are fully implemented
+  and integrate cleanly. Completing one of these satisfies the A-level "≥ 2 main features" bar.

--- a/docs/weekly-reports/report.md
+++ b/docs/weekly-reports/report.md
@@ -138,25 +138,27 @@
    PR ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/80))
 6. [in progress] Kris: Review extension to Game
    class ([GitHub PR](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/pull/84))
-7. [in progress] Brock: Review TradeBonus and
+7. [done, waiting for re-review] Brock: Review TradeBonus and
    CardTradePhase ([GitHub PR](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/pull/85))
 8. [in progress] Jefferson: Implement
    GameLoop ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/64))
-8. [not started] Brock: Update ReinforcementPhase: accept troopsToPlace externally, remove
+9. [not started] Brock: Update ReinforcementPhase: accept troopsToPlace externally, remove
    calculateTroops ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/72))
-9. [not started] Jefferson: Extend Game class: GameState enum, winner field, advanceToNextPlayer,
-   drawCard ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/70))
-10. [not started] Kris: Implement ConnectivityGraph and update
+10. [not started] Jefferson: Extend Game class: GameState enum, winner field, advanceToNextPlayer,
+    drawCard ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/70))
+11. [not started] Kris: Implement ConnectivityGraph and update
     FortificationPhase ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/69))
-11. [not started] Kris: Implement
+12. [not started] Kris: Implement
     GameSetup ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/68))
-12. [not started] Brock: Implement
+13. [done] Brock: Implement
     DeckManager ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/67))
-13. [not started] Kris/Jefferson: Fix SpotBugs
+14. [not started] Kris/Jefferson: Fix SpotBugs
     issues ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/86))
-14. [not started] Nandan/Brock: Implement integration
-    tests ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/78))
-15. [not started] All: Confirm project requirements and
+15. [done] Brock: Implement integration
+    test #1 ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/96))
+16. [not started] Nandan: Implement integration
+    test #2 ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/97))
+17. [not started] All: Confirm project requirements and
     functionality ([GitHub Task](https://github.com/nu-cs-sqe/course-project-20252603-team-11-20252603/issues/87))
 
 # Week X (XX/XX/2026-XX/XX/2026) TEMPLATE (You can change the format to whatever the team likes better)

--- a/src/test/java/domain/F6Tests.java
+++ b/src/test/java/domain/F6Tests.java
@@ -6,9 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +21,16 @@ import org.junit.jupiter.api.Test;
 // a real Game + DeckManager.
 public class F6Tests {
 
+  private static final int GAME_SEED = 1;
+  private static final int DICE_SEED = 7;
+  private static final int ATTACKER_ARMIES = 20;
+  private static final int SINGLE_ARMY = 1;
+  private static final int ATTACK_DICE = 1;
+  private static final int TROOPS_MOVED_IN = 3;
+  private static final int MIN_REMAINING_ARMIES = 1;
+  private static final int EXPECTED_CARDS_AWARDED = 1;
+  private static final int EXPECTED_SINGLE_ROUND_LOSS = 1;
+  private static final int NO_CONQUEST = 0;
   private static final int SAFETY_CAP = 1000;
 
   private GameMap map;
@@ -48,25 +56,25 @@ public class F6Tests {
 
     attacker.addTerritory(source);
     source.setOwner(attacker);
-    source.addTroops(20);
+    source.addTroops(ATTACKER_ARMIES);
 
     defender.addTerritory(target);
     target.setOwner(defender);
-    target.addTroops(1);
+    target.addTroops(SINGLE_ARMY);
 
     List<Player> players = new ArrayList<>();
     players.add(attacker);
     players.add(defender);
 
-    // a real deck-backed DeckManager
-    Deque<RiskCard> drawPile = new ArrayDeque<>();
-    drawPile.add(new RiskCard(RiskCardType.INFANTRY, target));
-    DeckManager deckManager = drawPile::pop;
+    // a real DeckManager seeded with one card to award on a successful conquest
+    Random gameRandom = new Random(GAME_SEED);
+    List<RiskCard> initialDrawPile = new ArrayList<>();
+    initialDrawPile.add(new RiskCard(RiskCardType.INFANTRY, target));
+    DeckManager deckManager = new DeckManager(gameRandom, initialDrawPile);
 
-    Random gameRandom = new Random(1);
-    game = new Game(players, map, new ArrayList<>(drawPile), gameRandom, deckManager);
+    game = new Game(players, map, deckManager, gameRandom);
 
-    diceRoller = new DiceRoller(new Random(7));
+    diceRoller = new DiceRoller(new Random(DICE_SEED));
     phase = new AttackPhase(attacker, diceRoller, game);
   }
 
@@ -74,46 +82,45 @@ public class F6Tests {
   public void attack_eligibleSourceAndAdjacentEnemy_canAttackAndDeclareSucceed() {
     assertTrue(phase.canAttack(source, target));
     // declareAttack validates ownership, dice bounds, troop count, and adjacency via GameMap
-    phase.declareAttack(source, target, 1);
+    phase.declareAttack(source, target, ATTACK_DICE);
   }
 
   @Test
   public void attack_resolveUntilConquest_transfersOwnershipAndAwardsCard() {
     int safety = 0;
-    while (phase.getConqueredCount() == 0) {
-      phase.resolveBattle(source, target, 1);
+    while (phase.getConqueredCount() == NO_CONQUEST) {
+      phase.resolveBattle(source, target, ATTACK_DICE);
       if (++safety > SAFETY_CAP) {
         fail("Attack never resolved to a conquest within the safety cap.");
       }
     }
 
-    int troopsMovedIn = 3;
-    phase.moveInTroops(source, target, troopsMovedIn);
+    phase.moveInTroops(source, target, TROOPS_MOVED_IN);
     phase.endPhase();
 
     // ownership transferred across the real Player/Territory objects
     assertEquals(attacker, target.getOwner());
     assertTrue(attacker.getTerritories().contains(target));
     assertFalse(defender.getTerritories().contains(target));
-    assertEquals(troopsMovedIn, target.getTroopCount());
+    assertEquals(TROOPS_MOVED_IN, target.getTroopCount());
     // source retained at least one army
-    assertTrue(source.getTroopCount() >= 1);
+    assertTrue(source.getTroopCount() >= MIN_REMAINING_ARMIES);
     // a card was awarded through Game + DeckManager because a territory was conquered
-    assertEquals(1, attacker.getCards().size());
+    assertEquals(EXPECTED_CARDS_AWARDED, attacker.getCards().size());
     assertTrue(phase.isEnded());
   }
 
   @Test
   public void attack_defenderSurvivesSingleRound_totalTroopsDropByExactlyOneAndNoConquest() {
     // two defenders means a single 1-die exchange cannot capture the territory
-    target.addTroops(1);
+    target.addTroops(SINGLE_ARMY);
     int before = source.getTroopCount() + target.getTroopCount();
 
-    phase.resolveBattle(source, target, 1);
+    phase.resolveBattle(source, target, ATTACK_DICE);
 
     int after = source.getTroopCount() + target.getTroopCount();
-    assertEquals(1, before - after);
-    assertEquals(0, phase.getConqueredCount());
+    assertEquals(EXPECTED_SINGLE_ROUND_LOSS, before - after);
+    assertEquals(NO_CONQUEST, phase.getConqueredCount());
   }
 
   @Test
@@ -121,10 +128,11 @@ public class F6Tests {
     Territory remote = new Territory("Remote");
     map.addTerritory(remote);
     remote.setOwner(defender);
-    remote.addTroops(1);
+    remote.addTroops(SINGLE_ARMY);
 
     // adjacency is enforced by the real GameMap, not a stub
-    assertThrows(IllegalArgumentException.class, () -> phase.declareAttack(source, remote, 1));
+    assertThrows(
+        IllegalArgumentException.class, () -> phase.declareAttack(source, remote, ATTACK_DICE));
   }
 
   @Test
@@ -134,7 +142,7 @@ public class F6Tests {
     map.addConnection(weak, target);
     attacker.addTerritory(weak);
     weak.setOwner(attacker);
-    weak.addTroops(1);
+    weak.addTroops(SINGLE_ARMY);
 
     assertFalse(phase.canAttack(weak, target));
   }

--- a/src/test/java/domain/F6Tests.java
+++ b/src/test/java/domain/F6Tests.java
@@ -1,0 +1,141 @@
+package domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+// Integration (thread) test for Feature F6: "Ability for players to initiate attacks on enemy
+// territories, with dice-rolling mechanics to decide attack outcomes."
+//
+// Unlike the per-class unit tests in this package, these tests wire real collaborators together
+// with no mocks: AttackPhase drives the real DiceRoller/BattleResult, mutating real
+// Territory/Player state, validating adjacency through a real GameMap, and awarding a card through
+// a real Game + DeckManager.
+public class F6Tests {
+
+  private static final int SAFETY_CAP = 1000;
+
+  private GameMap map;
+  private Player attacker;
+  private Player defender;
+  private Territory source;
+  private Territory target;
+  private Game game;
+  private DiceRoller diceRoller;
+  private AttackPhase phase;
+
+  @BeforeEach
+  public void setUp() {
+    map = new GameMap();
+    source = new Territory("Source");
+    target = new Territory("Target");
+    map.addTerritory(source);
+    map.addTerritory(target);
+    map.addConnection(source, target);
+
+    attacker = new Player("Attacker");
+    defender = new Player("Defender");
+
+    attacker.addTerritory(source);
+    source.setOwner(attacker);
+    source.addTroops(20);
+
+    defender.addTerritory(target);
+    target.setOwner(defender);
+    target.addTroops(1);
+
+    List<Player> players = new ArrayList<>();
+    players.add(attacker);
+    players.add(defender);
+
+    // a real deck-backed DeckManager
+    Deque<RiskCard> drawPile = new ArrayDeque<>();
+    drawPile.add(new RiskCard(RiskCardType.INFANTRY, target));
+    DeckManager deckManager = drawPile::pop;
+
+    Random gameRandom = new Random(1);
+    game = new Game(players, map, new ArrayList<>(drawPile), gameRandom, deckManager);
+
+    diceRoller = new DiceRoller(new Random(7));
+    phase = new AttackPhase(attacker, diceRoller, game);
+  }
+
+  @Test
+  public void attack_eligibleSourceAndAdjacentEnemy_canAttackAndDeclareSucceed() {
+    assertTrue(phase.canAttack(source, target));
+    // declareAttack validates ownership, dice bounds, troop count, and adjacency via GameMap
+    phase.declareAttack(source, target, 1);
+  }
+
+  @Test
+  public void attack_resolveUntilConquest_transfersOwnershipAndAwardsCard() {
+    int safety = 0;
+    while (phase.getConqueredCount() == 0) {
+      phase.resolveBattle(source, target, 1);
+      if (++safety > SAFETY_CAP) {
+        fail("Attack never resolved to a conquest within the safety cap.");
+      }
+    }
+
+    int troopsMovedIn = 3;
+    phase.moveInTroops(source, target, troopsMovedIn);
+    phase.endPhase();
+
+    // ownership transferred across the real Player/Territory objects
+    assertEquals(attacker, target.getOwner());
+    assertTrue(attacker.getTerritories().contains(target));
+    assertFalse(defender.getTerritories().contains(target));
+    assertEquals(troopsMovedIn, target.getTroopCount());
+    // source retained at least one army
+    assertTrue(source.getTroopCount() >= 1);
+    // a card was awarded through Game + DeckManager because a territory was conquered
+    assertEquals(1, attacker.getCards().size());
+    assertTrue(phase.isEnded());
+  }
+
+  @Test
+  public void attack_defenderSurvivesSingleRound_totalTroopsDropByExactlyOneAndNoConquest() {
+    // two defenders means a single 1-die exchange cannot capture the territory
+    target.addTroops(1);
+    int before = source.getTroopCount() + target.getTroopCount();
+
+    phase.resolveBattle(source, target, 1);
+
+    int after = source.getTroopCount() + target.getTroopCount();
+    assertEquals(1, before - after);
+    assertEquals(0, phase.getConqueredCount());
+  }
+
+  @Test
+  public void attack_nonAdjacentTarget_declareAttackRejectedViaGameMap() {
+    Territory remote = new Territory("Remote");
+    map.addTerritory(remote);
+    remote.setOwner(defender);
+    remote.addTroops(1);
+
+    // adjacency is enforced by the real GameMap, not a stub
+    assertThrows(IllegalArgumentException.class, () -> phase.declareAttack(source, remote, 1));
+  }
+
+  @Test
+  public void attack_sourceWithSingleArmy_cannotAttack() {
+    Territory weak = new Territory("Weak");
+    map.addTerritory(weak);
+    map.addConnection(weak, target);
+    attacker.addTerritory(weak);
+    weak.setOwner(attacker);
+    weak.addTroops(1);
+
+    assertFalse(phase.canAttack(weak, target));
+  }
+}


### PR DESCRIPTION
## Description
- Introduces the team's first integration (thread) test, following the course's recommended approach: integrate modules along a thread of execution that corresponds to a system feature, one test classper feature. 
- Covers F6: attacking enemy territories with dice mechanics, the richest fully-implemented feature.
- Using TDD / JUnit thread tests rather than BDD/Cucumber. The grading rubric treats TDD and BDD equally, and the integration-testing criteria (B: "progress on integration testing"; A: "≥ 2 main features") are method-agnostic, so no Gherkin/feature files are needed.

### Changes
- src/test/java/domain/F6Tests.java — 5 scenarios exercising the full attack thread with real collaborators and no mocks (the deliberate contrast with our existing EasyMock unit tests):
  - eligible source + adjacent enemy → canAttack/declareAttack succeed
  - resolve battles to conquest → ownership transfers across Player/Territory and a card is awarded via Game/DeckManager
  - defender survives a single round → total troops drop by exactly one, no conquest (deterministic invariant)
  - non-adjacent target → declareAttack rejected via real GameMap
  - single-army source → canAttack returns false
- docs/requirements/features.md — index of system features F1–F10 mapped to collaborator classes, tracking integration-test status (the slides ask features to be documented/indexed under
docs/requirements).

### Modules integrated on this thread
- AttackPhase → DiceRoller → BattleResult → Territory / Player → GameMap → Game → DeckManager
- Determinism is kept by seeding Random and looping resolveBattle to conquest, so no production class is mocked.
---
### Note for 2nd Integration Test @NanDhanesh 
**Reasoning for F7 (Fortify) being next integration test**
  - Fully implemented and rich. FortificationPhase (99 lines) integrates with GameMap, ConnectivityGraph, Player, and Territory — including BFS path-finding (GameMap.findPath) over only the player's own territories. That's a meaty, multi-module thread, and it's a different set of collaborators than F6, so it broadens coverage rather than overlapping.
  - Deterministic by nature. Unlike attack, fortify has no dice — so the tests need no seeding tricks and assert exact outcomes (path validity, troop movement, the once-per-turn rule).
  - Clearly a "main feature" in the rubric's sense, and pairing it with F6 cleanly satisfies the A-bar's "integration testing on at least 2 main features."

Alternative: F5 (Reinforcement) is also viable and a bit simpler (ReinforcementPhase + Player + Territory + continent-bonus logic), but it integrates fewer modules than F7. Avoid F9 (card trade) b/c CardTradePhase.execute() is still a // TODO stub, so there's nothing real to integrate yet.


## Related Task

Closes #96 

---

## ✅ PR Checklist

### 🧪 Testing

- [X] All existing automated tests pass
- [X] New code is covered by tests written **before** the implementation (TDD/BDD)
- [X] Test inputs and assertions are based on BVA analysis
- [X] Mutation testing has been run — **100% of non-equivalent mutants are killed**
- [X] **100% cyclomatic coverage** for all non-GUI and non-enum code
- [X] Integration tests updated/added if this PR touches a main feature (at least 2 main features must have integration
  tests by end of project)

### 🎨 Code Quality

- [X] Code fully satisfies the team's agreed style standards
- [X] Code follows **Clean Code** principles (meaningful names, small functions, no dead code, etc.)
- [X] No unnecessary comments and minimal TODOs left in

### 🌍 Localization (i18n)

- [X] Any new user-facing strings are externalized (not hardcoded)
- [X] Adding this change does not require modifying existing locale files to support a new language

### 🔁 Process

- [X] The corresponding task on the project management board is updated with a **detailed description**
- [X] This week's planning/progress notes are up to date in the team's documentation
- [X] This PR targets the correct branch and is **not** a direct push to `main`
- [X] CI pipeline passes ✅

---

## 📸 Screenshots / Evidence (if applicable)

<!-- Add screenshots, test output, or coverage reports here -->
