### PR TITLE
Feature/project close out

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Risk
 
+A digital implementation of the classic Risk board game set in the world of *Avatar: The Last Airbender*. The map replaces the standard world map with 42 territories across 5 factions: Moon Tribe, Ba Sing Se Kingdom, Fire Nation, Omashu Kingdom, and Ocean Tribe.
+
 ## Contributors
 
 - Jefferson Wu
@@ -11,12 +13,66 @@
 - Nandan Dhanesh
 - Brock Brown
 
+## Architecture
+
+The project is organized into three packages:
+
+| Package | Responsibility |
+|---|---|
+| `domain` | Core game logic — `Game`, `GameLoop`, `Player`, `Territory`, `GameMap`, `AtlaMapData`, and all phase classes (`SetupPhase`, `ReinforcementPhase`, `AttackPhase`, `FortificationPhase`, `CardTradePhase`). No dependency on `ui` or `i18n`. |
+| `i18n` | Internationalization facade (`Messages`) backed by Java `ResourceBundle`. Supports runtime locale switching (ships English and Spanish). |
+| `ui` | JavaFX front end — `Main`, `MapView`, `GameController`, `SidebarPanel`, `TerritoryNode`. Depends on `domain` and `i18n`; never imported by them. |
+
+## Test-Driven Development
+
+All `domain` classes were developed following strict **TDD**: BVA test cases were written and documented in `docs/bva/` before any production code for those classes. Unit tests use **JUnit 5** with **EasyMock** for collaborator isolation. Integration tests (`F6Tests`, `F7Tests`) wire real collaborators together with no mocks, covering the Attack and Fortify features end-to-end.
+
+**Note on internationalization (`i18n`):** The `Messages` class and its tests in `i18n/MessagesTests` were not developed under TDD. Internationalization was added through the UI layer, and we realized retrospectively that the course directions did not say to exclude i18n from testing. Tests were therefore added after the fact to achieve full non-GUI coverage. The BVA analysis for `Messages` is in `docs/bva/Messages.md`.
+
 ## Dependencies
 
-- JDK 11
-- JUnit 5.10
-- Gradle 8.10
+| Dependency | Version |
+|---|---|
+| JDK | 11 |
+| JavaFX | 17.0.6 |
+| JUnit 5 | 5.10.0 |
+| EasyMock | 5.4.0 |
+| Gradle | 8.10 |
+| Checkstyle | 10.21.4 |
+| JaCoCo | 0.8.12 |
+| PIT (mutation testing) | 1.15.0 |
+| SpotBugs | 4.8.6 |
+
+## Building and Running
+
+```bash
+# Run all tests
+./gradlew test
+
+# Launch the application
+./gradlew run
+
+# Generate JaCoCo coverage report  →  build/reports/jacoco/
+./gradlew jacocoTestReport
+
+# Run mutation testing  →  build/reports/pitest/
+./gradlew pitest
+
+# Run Checkstyle and SpotBugs static analysis
+./gradlew check
+```
+
+## Documentation
+
+| Document | Description |
+|---|---|
+| `docs/requirements/game-rules.md` | Human-readable game rules |
+| `docs/requirements/features.md` | Integration test index (F1–F10) |
+| `docs/design/README.md` | System design: use cases, class design, and architecture decisions |
+| `docs/bva/` | Boundary value analysis for every domain class |
+| `docs/weekly-reports/` | Weekly progress reports and instructor feedback |
 
 ## Acknowledgements
 
-REFERENCES, SOURCE OF HELP ETC
+- Game rules adapted from [Dice Breaker — How to Play Risk](https://www.dicebreaker.com/games/risk/how-to/how-to-play-risk-board-game)
+- Map and territory names themed around *Avatar: The Last Airbender*

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -1,22 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter
-    xmlns="https://github.com/spotbugs/filter/3.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
-
-  <!-- TODO: remove when Jefferson implements player-elimination logic. -->
-  <Match>
-    <Class name="domain.Player"/>
-    <Field name="isEliminated"/>
-    <Bug pattern="UWF_UNWRITTEN_FIELD"/>
-  </Match>
-
-  <!-- TODO: remove when Kris wires up hover/reset behavior using baseColor. -->
-  <Match>
-    <Class name="ui.TerritoryNode"/>
-    <Field name="baseColor"/>
-    <Bug pattern="URF_UNREAD_FIELD"/>
-  </Match>
+  xmlns="https://github.com/spotbugs/filter/3.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
 
   <!-- Test seam: the anonymous Turn subclass in buildTurn captures enclosing 'this' to
        reach the rp/ap/fp helper parameters. Refactoring to a named static inner class

--- a/docs/bva/Player.md
+++ b/docs/bva/Player.md
@@ -170,7 +170,7 @@
 - **TC49: card not present, hand is empty** ( :white_check_mark: )
   - **State of the system**: Player.cards is empty
   - **Expected output**: no-op; no exception; Player.cards.size() == 0
-- **TC50: card not present, hand is non-empty** ( )
+- **TC50: card not present, hand is non-empty** ( :white_check_mark: )
   - **State of the system**: Player.cards has 1 card; the card to remove is not in it
   - **Expected output**: no-op; no exception; Player.cards.size() unchanged
 - **TC51: card is the only card in the hand** ( )

--- a/docs/bva/Player.md
+++ b/docs/bva/Player.md
@@ -167,7 +167,7 @@
 - **TC48: null card** ( :white_check_mark: )
   - **State of the system**: Player created
   - **Expected output**: IllegalArgumentException thrown
-- **TC49: card not present, hand is empty** ( )
+- **TC49: card not present, hand is empty** ( :white_check_mark: )
   - **State of the system**: Player.cards is empty
   - **Expected output**: no-op; no exception; Player.cards.size() == 0
 - **TC50: card not present, hand is non-empty** ( )

--- a/docs/bva/Player.md
+++ b/docs/bva/Player.md
@@ -173,7 +173,7 @@
 - **TC50: card not present, hand is non-empty** ( :white_check_mark: )
   - **State of the system**: Player.cards has 1 card; the card to remove is not in it
   - **Expected output**: no-op; no exception; Player.cards.size() unchanged
-- **TC51: card is the only card in the hand** ( )
+- **TC51: card is the only card in the hand** ( :white_check_mark: )
   - **State of the system**: Player.cards has exactly [C1]
   - **Expected output**: Player.cards.size() == 0
 - **TC52: card is one of several in the hand** ( )

--- a/docs/bva/Player.md
+++ b/docs/bva/Player.md
@@ -179,6 +179,6 @@
 - **TC52: card is one of several in the hand** ( :white_check_mark: )
   - **State of the system**: Player.cards has [C1, C2]; remove C1
   - **Expected output**: Player.cards.size() == 1; C2 remains; C1 is gone
-- **TC53: hand contains two references to the same card object** ( )
+- **TC53: hand contains two references to the same card object** ( :white_check_mark: )
   - **State of the system**: Player.cards has [C1, C1] (same reference added twice)
   - **Expected output**: Player.cards.size() == 1; one copy of C1 remains

--- a/docs/bva/Player.md
+++ b/docs/bva/Player.md
@@ -162,3 +162,23 @@
 - **TC47: amount equals availableTroops (upper boundary)** ( :white_check_mark: )
   - **State of the system**: player owns territory; availableTroops = 5; amount = 5
   - **Expected output**: placement succeeds; availableTroops == 0
+
+### Method under test: `void removeCard(RiskCard card)`
+- **TC48: null card** ( )
+  - **State of the system**: Player created
+  - **Expected output**: IllegalArgumentException thrown
+- **TC49: card not present, hand is empty** ( )
+  - **State of the system**: Player.cards is empty
+  - **Expected output**: no-op; no exception; Player.cards.size() == 0
+- **TC50: card not present, hand is non-empty** ( )
+  - **State of the system**: Player.cards has 1 card; the card to remove is not in it
+  - **Expected output**: no-op; no exception; Player.cards.size() unchanged
+- **TC51: card is the only card in the hand** ( )
+  - **State of the system**: Player.cards has exactly [C1]
+  - **Expected output**: Player.cards.size() == 0
+- **TC52: card is one of several in the hand** ( )
+  - **State of the system**: Player.cards has [C1, C2]; remove C1
+  - **Expected output**: Player.cards.size() == 1; C2 remains; C1 is gone
+- **TC53: hand contains two references to the same card object** ( )
+  - **State of the system**: Player.cards has [C1, C1] (same reference added twice)
+  - **Expected output**: Player.cards.size() == 1; one copy of C1 remains

--- a/docs/bva/Player.md
+++ b/docs/bva/Player.md
@@ -176,7 +176,7 @@
 - **TC51: card is the only card in the hand** ( :white_check_mark: )
   - **State of the system**: Player.cards has exactly [C1]
   - **Expected output**: Player.cards.size() == 0
-- **TC52: card is one of several in the hand** ( )
+- **TC52: card is one of several in the hand** ( :white_check_mark: )
   - **State of the system**: Player.cards has [C1, C2]; remove C1
   - **Expected output**: Player.cards.size() == 1; C2 remains; C1 is gone
 - **TC53: hand contains two references to the same card object** ( )

--- a/docs/bva/Player.md
+++ b/docs/bva/Player.md
@@ -164,7 +164,7 @@
   - **Expected output**: placement succeeds; availableTroops == 0
 
 ### Method under test: `void removeCard(RiskCard card)`
-- **TC48: null card** ( )
+- **TC48: null card** ( :white_check_mark: )
   - **State of the system**: Player created
   - **Expected output**: IllegalArgumentException thrown
 - **TC49: card not present, hand is empty** ( )

--- a/docs/bva/RiskCard.md
+++ b/docs/bva/RiskCard.md
@@ -35,3 +35,11 @@
 ### Method under test: `Territory getTerritory()`
 
 Getter
+
+### Method under test: `String toString()`
+- **TC8: non-wildcard card** ( :x: )
+  - **State of the system**: RiskCard constructed with RiskCardType.INFANTRY
+  - **Expected output**: toString() returns "INFANTRY"
+- **TC9: wildcard card** ( :x: )
+  - **State of the system**: RiskCard constructed with RiskCardType.WILDCARD and null territory
+  - **Expected output**: toString() returns "WILDCARD"

--- a/docs/bva/RiskCard.md
+++ b/docs/bva/RiskCard.md
@@ -37,7 +37,7 @@
 Getter
 
 ### Method under test: `String toString()`
-- **TC8: non-wildcard card** ( :x: )
+- **TC8: non-wildcard card** ( :white_check_mark: )
   - **State of the system**: RiskCard constructed with RiskCardType.INFANTRY
   - **Expected output**: toString() returns "INFANTRY"
 - **TC9: wildcard card** ( :x: )

--- a/docs/bva/RiskCard.md
+++ b/docs/bva/RiskCard.md
@@ -40,6 +40,6 @@ Getter
 - **TC8: non-wildcard card** ( :white_check_mark: )
   - **State of the system**: RiskCard constructed with RiskCardType.INFANTRY
   - **Expected output**: toString() returns "INFANTRY"
-- **TC9: wildcard card** ( :x: )
+- **TC9: wildcard card** ( :white_check_mark: )
   - **State of the system**: RiskCard constructed with RiskCardType.WILDCARD and null territory
   - **Expected output**: toString() returns "WILDCARD"

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,1 +1,365 @@
-This folder should include the system design. It can be in the form of design diagrams or a textual description of what classes the system shall have and their relationships.
+# System Design
+
+> **Note:** This design was created collaboratively in a [Google Document](https://docs.google.com/document/d/1YCv8tL5Uc0MT8etI7hFDUxLlvCKmzwen8G1awSIu3ZA/edit) before any production code was written. The document was used to agree on use cases, class responsibilities, and method signatures up front. This README is a transcription of that plan, updated to reflect the final implementation, produced at project close-out.
+
+---
+
+## Overview
+
+The system implements a digital version of Risk themed around *Avatar: The Last Airbender*. The board has 42 territories organized into 5 factions (continents). All game logic lives in the `domain` package, which has no dependency on the UI or i18n layers.
+
+---
+
+## Territory Map
+
+### Moon Tribe — 7 territories *(Color: Gray)*
+
+Northern Tundra, Frost Hills, Moon Tribe, Bin-Er, Yue Bay, Wulong, Western Air Temple
+
+### Ba Sing Se Kingdom — 10 territories *(Color: Green)*
+
+Zigan, Northern Air Temple, Northern Mountains, Taihua, Ba Sing Se City, Ba Sing Se Province, Continental Corridor, Taku, Green Farmlands, Charmeleon Province
+
+### Fire Nation — 7 territories *(Color: Red)*
+
+Sun Isles, Burning Gates, Caldera City, Black Cliffs, Keonso, Fire Archipelago, Whale Tail Isle
+
+### Omashu Kingdom — 10 territories *(Color: Tan/Beige)*
+
+Hei Bei, Great Divide, Serpent Pass, Full Moon Bay, Omashu, Western Si Wong Desert, Eastern Si Wong Desert, Heart Farmlands, Chin, Gao Ling
+
+### Ocean Tribe — 8 territories *(Color: Light Blue)*
+
+Eastern Air Temple, Seafoam Isles, Hakoda Island, Shimsom Isle, Southern Air Temple, Ocean Tribe, Southern Tundra, Icy Plains
+
+---
+
+## Class Design
+
+### `Territory`
+
+Represents one territory on the board.
+
+**Fields:** `name: String`, `owner: Player`, `troopCount: int`
+
+**Key methods:** `addTroops(int)`, `removeTroops(int)`, `getTroopCount()`, `getOwner()`, `setOwner(Player)`, `getName()`, `conquer(Player newOwner, int troopsMovedIn)`
+
+---
+
+### `GameMap`
+
+Owns the territory graph. Adjacency is stored as `Map<Territory, Set<Territory>>`.
+
+**Key methods:** `addTerritory(Territory)`, `addConnection(Territory, Territory)`, `getTerritories()`, `getNeighbors(Territory)`, `areAdjacent(Territory, Territory)`, `findPath(Territory, Territory, Player)`
+
+---
+
+### `AtlaMapData`
+
+Owns the 5 faction groupings and their territory membership. `buildMap()` constructs the full 42-territory `GameMap` with all adjacencies. `continentCount()` returns 5.
+
+---
+
+### `Player`
+
+Represents one player in the game.
+
+**Fields:** `name: String`, `territories: List<Territory>`, `cards: List<RiskCard>`, `availableTroops: int`, `isEliminated: boolean`
+
+**Key methods:** `addTerritory(Territory)`, `removeTerritory(Territory)`, `addCard(RiskCard)`, `inheritCardsFrom(Player)`, `calculateReinforcements()`, `getAvailableTroops()`, `setAvailableTroops(int)`, `getTerritoryCount()`, `getCardCount()`, `isEliminated()`, `setEliminated(boolean)`
+
+---
+
+### `RiskCard`
+
+**Fields:** `riskCardType: RiskCardType`, `territory: Territory`
+
+**Key methods:** `getType()`, `getTerritory()`
+
+---
+
+### `RiskCardType` (enum)
+
+`INFANTRY`, `CAVALRY`, `ARTILLERY`, `WILDCARD`
+
+---
+
+### `GameState` (enum)
+
+`SETUP`, `IN_PROGRESS`, `FINISHED`
+
+---
+
+### `Game`
+
+Aggregate root. Holds all shared game state.
+
+**Fields:** `players: List<Player>`, `map: GameMap`, `deckManager: DeckManager`, `random: Random`, `gameState: GameState`, `winner: Optional<Player>`, `currentPlayerIndex: int`
+
+**Key methods:** `assignTerritories()`, `distributeStartingTroops()`, `chooseFirstPlayer()`, `getCurrentActivePlayer()`, `setGameState(GameState)`, `setWinner(Player)`, `getPlayers()`, `getMap()`, `getRandom()`
+
+---
+
+### `DeckManager`
+
+Manages the 42-card Risk deck: building, shuffling, drawing, and the discard pile.
+
+**Key methods:** `buildDeck(List<Territory>)`, `shuffle()`, `draw()`, `returnCards(List<RiskCard>)`, `getDrawPileSize()`, `getDiscardPileSize()`
+
+---
+
+### `SetupPhase`
+
+Orchestrates game initialization.
+
+**Key methods:** `assignTerritories()`, `distributeStartingTroops()`, `chooseFirstPlayer()`, `run()`
+
+---
+
+### `ReinforcementPhase`
+
+Constructed with `troopsToPlace` pre-calculated by `GameLoop`. Handles interactive troop placement.
+
+**Key methods:** `validatePlacement(int troops, Territory)`, `placeTroops(int troops, Territory)`, `getRemaining()`, `isComplete()`
+
+---
+
+### `AttackPhase`
+
+Manages the attack sequence. The attack is split into discrete steps so the UI can prompt the player between each.
+
+**Key methods:** `declareAttack(Territory s, Territory t, int n)`, `resolveBattle(Territory s, Territory t, int n)`, `moveInTroops(Territory s, Territory t, int n)`, `canAttack(Territory s, Territory t)`, `awardCardIfEarned()`, `endPhase()`, `isEnded()`, `getConqueredCount()`
+
+---
+
+### `DiceRoller`
+
+Rolls and compares dice for a single battle.
+
+**Key methods:** `rollAttacker(int n)` → `List<Integer>`, `rollDefender(int n)` → `List<Integer>`, `sortDescending(List<Integer>)`, `compare(List<Integer> attackerDice, List<Integer> defenderDice)` → `BattleResult`
+
+---
+
+### `BattleResult`
+
+Immutable value produced by `DiceRoller.compare()`. Computes losses from sorted dice lists in its constructor.
+
+**Key methods:** `getAttackerLosses()`, `getDefenderLosses()`, `isConquered()`
+
+---
+
+### `FortificationPhase`
+
+Validates connectivity through player-owned territories and enforces the once-per-turn rule.
+
+**Key methods:** `moveTroops(Territory s, Territory d, int n)`, `validateMove(Territory s, Territory d, int n)`, `skipPhase()`, `isMoved()`, `isComplete()`, `isConnected(Territory s, Territory d)`, `findPath(Territory s, Territory d)`
+
+---
+
+### `ConnectivityGraph`
+
+Ownership-aware BFS over `GameMap`.
+
+**Key methods:** `isConnected(Territory s, Territory d, Player owner)`, `findPath(Territory s, Territory d, Player owner)`, `getReachable(Territory src, Player owner)`
+
+---
+
+### `Turn`
+
+Represents one player's full turn. Runs all three phases in order.
+
+**Key methods:** `startTurn()`, `runReinforcementPhase()`, `runAttackPhase()`, `runFortificationPhase()`, `endTurn()`, `getEliminatedDefender()` → `Optional<Player>`, `hasConqueredThisTurn()`
+
+---
+
+### `GameLoop`
+
+Central coordinator for the main game loop. Manages the `TradeBonus` counter.
+
+**Key methods:** `start()`, `runNextTurn()`, `checkWinCondition()`
+
+---
+
+### `CardTradePhase`
+
+Manages the pre-reinforcement card trading phase. `mandatory` is `true` when the player holds ≥ 5 cards.
+
+**Constants:** `PRE_TURN_THRESHOLD = 5`, `POST_ELIMINATION_THRESHOLD = 6`
+
+**Key methods:** `validateSet(List<RiskCard>)`, `run()`, `isComplete()`
+
+---
+
+### `CardTradeValidator`
+
+Pure logic class with no state.
+
+**Key methods:** `isValidSet(List<RiskCard>)`, `mustTrade(Player)`, `isMandatory(Player)`
+
+---
+
+### `TradeBonus`
+
+Tracks the globally incrementing trade bonus. Starts at 4; increments by 2 each trade.
+
+**Key methods:** `getValue()`, `increment()`
+
+---
+
+## Use Cases
+
+### Use Case 1: Start New Game
+
+**Actor:** Player
+
+**Preconditions:** The game application is launched.
+
+**Main Flow:**
+1. Player clicks "Start Game"
+2. System prompts for the number of players
+3. Player enters number of players
+4. System validates (2–6 players)
+5. System shows the map
+6. System randomly distributes all territories among players
+7. System assigns 1 army to each territory
+8. System calculates remaining armies per player based on player count
+9. System allows players to place remaining armies
+10. System randomizes turn order
+11. System transitions to the first player's turn
+
+**Alternate Flows:**
+- *3.a Invalid number of players:* System displays error; user re-enters.
+
+**Postconditions:** All territories are assigned with 1 army each; all players have placed their initial armies; turn order is established.
+
+---
+
+### Use Case 2: Reinforcement Phase
+
+**Actor:** Current Player
+
+**Preconditions:** It is the current player's turn; game is not in setup or end-game state; current player owns at least one territory.
+
+**Main Flow:**
+1. System calculates reinforcement armies: `max(3, territories_owned ÷ 3)` plus any continent bonuses
+2. System displays available reinforcements
+3. Player selects an owned territory and enters armies to place
+4. System validates and adds armies; decrements available troops
+5. Steps 3–4 repeat until available troops reach zero
+6. System transitions to attack phase
+
+**Alternate Flows:**
+- *3.a Player selects unowned territory:* Error; return to step 3.
+- *3.b Player enters more armies than available:* Error; return to step 3.
+
+---
+
+### Use Case 3: Attack Phase
+
+**Actor:** Current Player (attacker), Other Player (defender)
+
+**Preconditions:** Reinforcement phase complete; attacker owns a territory with ≥ 2 armies adjacent to an enemy territory.
+
+**Main Flow:**
+1. Player selects an owned source territory (≥ 2 armies) and an adjacent enemy target territory
+2. Player chooses attacking dice count (1–3, capped by source armies − 1)
+3. System rolls defender dice (1–2, capped by target armies) and compares pairs in descending order; ties go to defender
+4. Each losing comparison costs that side 1 army
+5. If target reaches 0 armies: attacker captures territory; attacker must move in ≥ attacking dice armies (and ≤ source armies − 1)
+6. Player may continue attacking from step 1 or end the attack phase
+7. If player conquered any territory this turn, system awards 1 Risk card via `awardCardIfEarned()`
+
+**Alternate Flows:**
+- *Source territory < 2 armies:* Error.
+- *Target not adjacent or owned by attacker:* Error.
+- *Armies to move in out of valid range:* Error.
+
+---
+
+### Use Case 4: Fortification Phase
+
+**Actor:** Current Player
+
+**Preconditions:** Attack phase complete; current player owns ≥ 2 connected territories with at least one having > 1 army.
+
+**Main Flow:**
+1. Player selects an owned source territory (≥ 2 armies)
+2. Player selects a destination territory owned by the current player and **connected through a chain of owned territories** (not required to be directly adjacent)
+3. Player enters armies to move (1 to source armies − 1)
+4. System validates connectivity via `ConnectivityGraph` and army count, then moves armies
+5. System ends the turn and advances to the next player
+
+**Alternate Flows:**
+- *Player skips fortification:* `skipPhase()` called; proceed to step 5.
+- *Destination not reachable through owned territories:* Error; return to step 2.
+- *Movement would leave source with 0 armies:* Error; return to step 3.
+
+**Postconditions:** At most one army movement occurred this turn; every territory the current player owns has ≥ 1 army; next player is now active.
+
+---
+
+### Use Case 5: Game Loop
+
+**Actor:** Game System
+
+**Main Flow:**
+1. System identifies current player (by `currentPlayerIndex`)
+2. If current player is eliminated, advance index and repeat step 1
+3. Check win condition: if only one active player remains, declare winner and transition to `FINISHED`
+4. If player holds ≥ 5 cards, run `CardTradePhase` (mandatory = true)
+5. Calculate reinforcements via `player.calculateReinforcements()`; create and run `Turn`
+6. After turn: check if a defender was eliminated; if so, transfer cards to attacker via `inheritCardsFrom(Player)`
+7. If attacker now holds ≥ 6 cards, run `CardTradePhase` (mandatory = true)
+8. Re-check win condition; advance `currentPlayerIndex`; return to step 1
+
+---
+
+### Use Case 6: Card Trading Phase
+
+**Actor:** Current Player
+
+**Preconditions:** Player holds ≥ 3 cards.
+
+**Main Flow:**
+1. If player holds ≥ 5 cards, trading is mandatory
+2. Player selects a valid 3-card set (three of the same type, one of each, or any set containing a wildcard)
+3. System validates the set via `CardTradeValidator.isValidSet()`; cards are removed from hand
+4. `CardTradePhase.run()` awards `TradeBonus.getValue()` troops and increments the bonus
+5. If player still holds ≥ 5 cards, return to step 2
+
+---
+
+### Use Case 7: Win Condition Check
+
+**Actor:** Game System
+
+**Main Flow:**
+1. Count active players (not eliminated, owns ≥ 1 territory)
+2. If exactly one remains, declare that player the winner
+3. Transition to `FINISHED` state via `game.setGameState(GameState.FINISHED)` and `game.setWinner(Player)`
+
+---
+
+## Design Decisions
+
+### Changes from Initial Google Doc Design
+
+| Decision | Original Plan | Final Implementation |
+|---|---|---|
+| Troop calculation | `ReinforcementPhase` computed its own troop count | `GameLoop` calls `player.calculateReinforcements()` and passes the result into the `ReinforcementPhase` constructor |
+| Attack API | Single `attack()` method | Split into `declareAttack()`, `resolveBattle()`, and `moveInTroops()` so the UI can prompt between steps |
+| Adjacency storage | `Map<Territory, List<Territory>>` | `Map<Territory, Set<Territory>>` to prevent duplicate edges |
+
+### Gap Resolution
+
+The initial design identified three classes that were referenced but not yet designed. All three were implemented:
+
+| Gap | Resolution |
+|---|---|
+| Territory connectivity for `FortificationPhase` | `ConnectivityGraph` — ownership-aware BFS over `GameMap` |
+| Deck management | `DeckManager` — builds the 42-card deck, handles shuffle, draw, and discard |
+| Game initialization algorithms | `SetupPhase` — random territory assignment and troop distribution |
+
+### Army Representation
+
+Only infantry pieces are used. Card set trade-in values follow the course use-cases model as a system-enforced calculation starting at 4 troops and increasing by 2 with each trade globally.

--- a/docs/requirements/features.md
+++ b/docs/requirements/features.md
@@ -25,12 +25,12 @@ covered.
 | F6  | Attack enemy territories with dice mechanics | `AttackPhase`, `DiceRoller`, `BattleResult`, `Territory`, `Player`, `GameMap`, `Game`, `DeckManager` | ✅ `F6Tests.java` |
 | F7  | Fortify: move armies between owned territories | `FortificationPhase`, `GameMap`, `Player`, `Territory`, `ConnectivityGraph` | ✅ `F7Tests.java` |
 | F8  | Earn a card for a successful attack (one per turn) | `AttackPhase`, `Game`, `DeckManager`, `RiskCard`, `Player` | partially via F6 |
-| F9  | Trade cards for reinforcements | `CardTradePhase`, `CardTradeValidator`, `Player`, `RiskCard` | — (impl in progress) |
+| F9  | Trade cards for reinforcements | `CardTradePhase`, `CardTradeValidator`, `Player`, `RiskCard` | unit-tested (`CardTradePhaseTests`, `CardTradeValidatorTests`) |
 | F10 | Detect win (capture all territories / eliminate all players) | `GameLoop`, `Game`, `Player` | — |
 
 ## Status
 
-The A-level "integration testing on ≥ 2 main features" bar is met by **F6** and **F7**.
+All features F1–F10 are fully implemented. The A-level "integration testing on ≥ 2 main features" bar is met by **F6** and **F7**. All remaining features have dedicated unit test classes in `src/test/java/domain/`.
 
 - **F6 (Attack)** — covered by `src/test/java/domain/F6Tests.java`. Exercises the full attack
   thread end to end: adjacency validation through `GameMap`, dice resolution through the real

--- a/docs/requirements/game-rules.md
+++ b/docs/requirements/game-rules.md
@@ -7,8 +7,8 @@ of the game is to conquer every territory on the board and eliminate all opponen
 
 ## The "Board"
 
-The board (GUI) will display a map of Northwestern University divded into ? territories and
-? continents. Each territory shows:
+The board (GUI) will display a map themed around *Avatar: The Last Airbender*, divided into
+42 territories and 5 factions (continents). Each territory shows:
 
 - The territory name
 - The number of armies currently stationed there
@@ -52,8 +52,8 @@ attack.
 
 ### 3. Fortify *(optional)*
 
-Click one of your territories, then click an adjacent territory you own to move armies between them.
-You may only fortify once per turn. When you're done, click End Turn.
+Click one of your territories, then click a territory you own that is connected through a chain
+of your own territories. You may only fortify once per turn. When you're done, click End Turn.
 
 ## Risk Cards
 

--- a/src/main/java/domain/Player.java
+++ b/src/main/java/domain/Player.java
@@ -84,6 +84,7 @@ public class Player {
     if (card == null) {
       throw new IllegalArgumentException("Card cannot be null.");
     }
+    cards.remove(card);
   }
 
   public void inheritCardsFrom(Player eliminated) {

--- a/src/main/java/domain/Player.java
+++ b/src/main/java/domain/Player.java
@@ -80,6 +80,12 @@ public class Player {
     cards.add(card);
   }
 
+  public void removeCard(RiskCard card) {
+    if (card == null) {
+      throw new IllegalArgumentException("Card cannot be null.");
+    }
+  }
+
   public void inheritCardsFrom(Player eliminated) {
     if (eliminated == null) {
       throw new IllegalArgumentException("Eliminated player cannot be null.");

--- a/src/main/java/domain/RiskCard.java
+++ b/src/main/java/domain/RiskCard.java
@@ -35,4 +35,9 @@ public class RiskCard {
   public Territory getTerritory() {
     return this.territory;
   }
+
+  @Override
+  public String toString() {
+    return riskCardType.name();
+  }
 }

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -188,7 +188,10 @@ public final class GameController {
     currentTurn.endTurn();
     currentTurn.getEliminatedDefender().ifPresent(defender -> {
       currentTurn.getCurrentPlayer().inheritCardsFrom(defender);
-      // TODO: drive post-elimination trading via UI when >= POST_ELIMINATION_THRESHOLD
+      if (currentTurn.getCurrentPlayer().getCards().size()
+          >= CardTradePhase.POST_ELIMINATION_THRESHOLD) {
+        runMandatoryCardTradeLoop(currentTurn.getCurrentPlayer());
+      }
     });
     if (!checkAndHandleWinCondition()) {
       startNextTurn();

--- a/src/main/java/ui/GameController.java
+++ b/src/main/java/ui/GameController.java
@@ -1,13 +1,17 @@
 package ui;
 
 import domain.AttackPhase;
+import domain.CardTradePhase;
+import domain.CardTradeValidator;
 import domain.FortificationPhase;
 import domain.Game;
 import domain.GameMap;
 import domain.GameState;
 import domain.Player;
 import domain.ReinforcementPhase;
+import domain.RiskCard;
 import domain.Territory;
+import domain.TradeBonus;
 import domain.Turn;
 import domain.TurnPhase;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -22,7 +26,11 @@ import javafx.scene.control.TextInputDialog;
 
 public final class GameController {
 
+  private static final int INITIAL_TRADE_BONUS = 4;
+  private static final int TRADE_BONUS_INCREMENT = 2;
+
   private final Game game;
+  private final TradeBonus tradeBonus;
   private Turn currentTurn;
   private Territory selectedTerritory;
   private Runnable onStateChanged;
@@ -35,6 +43,7 @@ public final class GameController {
       throw new IllegalArgumentException("game cannot be null");
     }
     this.game = game;
+    this.tradeBonus = new TradeBonus(INITIAL_TRADE_BONUS, TRADE_BONUS_INCREMENT);
     autoPlaceStartingTroops();
     startNextTurn();
   }
@@ -166,7 +175,9 @@ public final class GameController {
 
   private void startNextTurn() {
     Player currentPlayer = game.getCurrentActivePlayer();
-    // TODO: drive pre-turn trading via UI when player has >= PRE_TURN_THRESHOLD cards
+    if (currentPlayer.getCards().size() >= CardTradePhase.PRE_TURN_THRESHOLD) {
+      runMandatoryCardTradeLoop(currentPlayer);
+    }
     currentTurn = new Turn(currentPlayer, game, game.getRandom());
     currentTurn.startTurn();
     selectedTerritory = null;
@@ -382,6 +393,52 @@ public final class GameController {
     } catch (NumberFormatException e) {
       return Optional.of(min);
     }
+  }
+
+  private void runMandatoryCardTradeLoop(Player player) {
+    CardTradePhase phase = new CardTradePhase(
+        player, tradeBonus, true, new CardTradeValidator());
+    while (!phase.isComplete()) {
+      List<RiskCard> picks = pickTradeCards(player);
+      if (!phase.validateSet(picks)) {
+        showTradeInvalidAlert();
+        continue;
+      }
+      for (RiskCard card : picks) {
+        player.removeCard(card);
+      }
+      phase.run();
+      phase = new CardTradePhase(player, tradeBonus, true, new CardTradeValidator());
+    }
+  }
+
+  private List<RiskCard> pickTradeCards(Player player) {
+    List<RiskCard> picks = new ArrayList<>();
+    List<RiskCard> remaining = new ArrayList<>(player.getCards());
+    for (int pick = 0; pick < 3; pick++) {
+      picks.add(showCardPickDialog(remaining));
+      remaining.remove(picks.get(pick));
+    }
+    return picks;
+  }
+
+  private RiskCard showCardPickDialog(List<RiskCard> choices) {
+    RiskCard result = null;
+    while (result == null) {
+      ChoiceDialog<RiskCard> dialog = new ChoiceDialog<>(choices.get(0), choices);
+      dialog.setTitle(Messages.get("ui.dialog.cardTrade.title"));
+      dialog.setHeaderText(Messages.get("ui.dialog.cardTrade.header"));
+      result = dialog.showAndWait().orElse(null);
+    }
+    return result;
+  }
+
+  private void showTradeInvalidAlert() {
+    Alert alert = new Alert(Alert.AlertType.WARNING);
+    alert.setTitle(Messages.get("ui.dialog.cardTrade.title"));
+    alert.setHeaderText(null);
+    alert.setContentText(Messages.get("ui.dialog.cardTrade.invalid"));
+    alert.showAndWait();
   }
 
   private void showError(String message) {

--- a/src/main/java/ui/TerritoryNode.java
+++ b/src/main/java/ui/TerritoryNode.java
@@ -25,7 +25,6 @@ public final class TerritoryNode extends Group {
   private static final Color OWNER_FILL = Color.WHITE;
 
   private final Territory territory;
-  private final Color baseColor;
   private final String msgKey;
   private final Polygon shape;
   private final Text troopLabel;
@@ -36,12 +35,12 @@ public final class TerritoryNode extends Group {
 
   @SuppressFBWarnings(
       value = "EI_EXPOSE_REP2",
-      justification = "Territory is the shared aggregate domain object; TerritoryNode needs the "
-          + "live reference to read troop count and owner for display refresh.")
+      justification =
+          "Territory is the shared aggregate domain object; TerritoryNode needs the "
+              + "live reference to read troop count and owner for display refresh.")
   public TerritoryNode(
       Territory territory, Color baseColor, double cx, double cy, double radius, String msgKey) {
     this.territory = territory;
-    this.baseColor = baseColor;
     this.msgKey = msgKey;
 
     this.shape = buildHexagon(cx, cy, radius);
@@ -57,10 +56,10 @@ public final class TerritoryNode extends Group {
     shape.setOnMouseExited(e -> shape.setFill(baseColor));
     shape.setOnMouseClicked(e -> clickHandler.run());
 
-    this.troopLabel = new Text(cx + LABEL_DX, cy + LABEL_DY,
-        String.valueOf(territory.getTroopCount()));
-    this.ownerMarker = buildOwnerMarker(
-        cx + radius * OWNER_OFFSET, cy - radius * OWNER_OFFSET, territory);
+    this.troopLabel =
+        new Text(cx + LABEL_DX, cy + LABEL_DY, String.valueOf(territory.getTroopCount()));
+    this.ownerMarker =
+        buildOwnerMarker(cx + radius * OWNER_OFFSET, cy - radius * OWNER_OFFSET, territory);
 
     getChildren().addAll(shape, troopLabel, ownerMarker);
   }

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -93,6 +93,9 @@ ui.instruction.fortification=Click a source, then a connected owned territory.
 ui.dialog.troops=How many troops?
 ui.dialog.dice=How many dice? (1-{0})
 ui.dialog.moveIn=Move in how many troops? (min {0})
+ui.dialog.cardTrade.title=Card Trade
+ui.dialog.cardTrade.header=Select a card to trade
+ui.dialog.cardTrade.invalid=Invalid card set. Please select a valid combination.
 
 # Game over
 ui.winner={0} wins!

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -93,6 +93,9 @@ ui.instruction.fortification=Haz clic en origen, luego en un territorio conectad
 ui.dialog.troops=¿Cuántas tropas?
 ui.dialog.dice=¿Cuántos dados? (1-{0})
 ui.dialog.moveIn=¿Cuántas tropas mover? (mín. {0})
+ui.dialog.cardTrade.title=Comercio de Cartas
+ui.dialog.cardTrade.header=Selecciona una carta para comerciar
+ui.dialog.cardTrade.invalid=Combinación no válida. Por favor, selecciona una combinación válida.
 
 # Game over
 ui.winner=¡{0} gana!

--- a/src/test/java/domain/PlayerTests.java
+++ b/src/test/java/domain/PlayerTests.java
@@ -415,6 +415,18 @@ public class PlayerTests {
   }
 
   @Test
+  public void removeCard_cardAbsentNonEmptyHand_sizeUnchanged() {
+    Player player = new Player("Alice");
+    RiskCard present = EasyMock.createMock(RiskCard.class);
+    RiskCard absent = EasyMock.createMock(RiskCard.class);
+    EasyMock.replay(present, absent);
+    player.addCard(present);
+    player.removeCard(absent);
+    assertEquals(1, player.getCardCount());
+    EasyMock.verify(present, absent);
+  }
+
+  @Test
   public void removeCard_emptyHand_noOpNoException() {
     Player player = new Player("Alice");
     RiskCard card = EasyMock.createMock(RiskCard.class);

--- a/src/test/java/domain/PlayerTests.java
+++ b/src/test/java/domain/PlayerTests.java
@@ -415,6 +415,18 @@ public class PlayerTests {
   }
 
   @Test
+  public void removeCard_duplicateCardReference_firstOccurrenceRemoved() {
+    Player player = new Player("Alice");
+    RiskCard card = EasyMock.createMock(RiskCard.class);
+    EasyMock.replay(card);
+    player.addCard(card);
+    player.addCard(card);
+    player.removeCard(card);
+    assertEquals(1, player.getCardCount());
+    EasyMock.verify(card);
+  }
+
+  @Test
   public void removeCard_oneOfManyCards_shrinksAndRemovesTarget() {
     Player player = new Player("Alice");
     RiskCard card1 = EasyMock.createMock(RiskCard.class);

--- a/src/test/java/domain/PlayerTests.java
+++ b/src/test/java/domain/PlayerTests.java
@@ -415,6 +415,21 @@ public class PlayerTests {
   }
 
   @Test
+  public void removeCard_oneOfManyCards_shrinksAndRemovesTarget() {
+    Player player = new Player("Alice");
+    RiskCard card1 = EasyMock.createMock(RiskCard.class);
+    RiskCard card2 = EasyMock.createMock(RiskCard.class);
+    EasyMock.replay(card1, card2);
+    player.addCard(card1);
+    player.addCard(card2);
+    player.removeCard(card1);
+    assertEquals(1, player.getCardCount());
+    assertFalse(player.getCards().contains(card1));
+    assertTrue(player.getCards().contains(card2));
+    EasyMock.verify(card1, card2);
+  }
+
+  @Test
   public void removeCard_onlyCardInHand_handBecomesEmpty() {
     Player player = new Player("Alice");
     RiskCard card = EasyMock.createMock(RiskCard.class);

--- a/src/test/java/domain/PlayerTests.java
+++ b/src/test/java/domain/PlayerTests.java
@@ -415,6 +415,17 @@ public class PlayerTests {
   }
 
   @Test
+  public void removeCard_onlyCardInHand_handBecomesEmpty() {
+    Player player = new Player("Alice");
+    RiskCard card = EasyMock.createMock(RiskCard.class);
+    EasyMock.replay(card);
+    player.addCard(card);
+    player.removeCard(card);
+    assertEquals(0, player.getCardCount());
+    EasyMock.verify(card);
+  }
+
+  @Test
   public void removeCard_cardAbsentNonEmptyHand_sizeUnchanged() {
     Player player = new Player("Alice");
     RiskCard present = EasyMock.createMock(RiskCard.class);

--- a/src/test/java/domain/PlayerTests.java
+++ b/src/test/java/domain/PlayerTests.java
@@ -414,6 +414,12 @@ public class PlayerTests {
     EasyMock.verify(territory);
   }
 
+  @Test
+  public void removeCard_nullCard_throwsIllegalArgumentException() {
+    Player player = new Player("Alice");
+    assertThrows(IllegalArgumentException.class, () -> player.removeCard(null));
+  }
+
   // calculateReinforcements tests
   @ParameterizedTest
   @CsvSource({"0,  3", "1,  3", "2,  3", "3,  3", "9,  3", "10, 3", "11, 3", "12, 4", "30, 10"})

--- a/src/test/java/domain/PlayerTests.java
+++ b/src/test/java/domain/PlayerTests.java
@@ -415,6 +415,16 @@ public class PlayerTests {
   }
 
   @Test
+  public void removeCard_emptyHand_noOpNoException() {
+    Player player = new Player("Alice");
+    RiskCard card = EasyMock.createMock(RiskCard.class);
+    EasyMock.replay(card);
+    assertDoesNotThrow(() -> player.removeCard(card));
+    assertEquals(0, player.getCardCount());
+    EasyMock.verify(card);
+  }
+
+  @Test
   public void removeCard_nullCard_throwsIllegalArgumentException() {
     Player player = new Player("Alice");
     assertThrows(IllegalArgumentException.class, () -> player.removeCard(null));

--- a/src/test/java/domain/RiskCardTests.java
+++ b/src/test/java/domain/RiskCardTests.java
@@ -81,4 +81,10 @@ public class RiskCardTests {
     RiskCard card = new RiskCard(RiskCardType.INFANTRY, t);
     assertEquals("INFANTRY", card.toString());
   }
+
+  @Test
+  public void toString_wildcardCard_returnsTypeName() {
+    RiskCard card = new RiskCard(RiskCardType.WILDCARD, null);
+    assertEquals("WILDCARD", card.toString());
+  }
 }

--- a/src/test/java/domain/RiskCardTests.java
+++ b/src/test/java/domain/RiskCardTests.java
@@ -73,4 +73,12 @@ public class RiskCardTests {
 
     assertEquals(RiskCardType.WILDCARD, card.getType());
   }
+
+  @Test
+  public void toString_infantryCard_returnsTypeName() {
+    Player p = EasyMock.createMock(Player.class);
+    Territory t = new Territory("Alaska", p, 1);
+    RiskCard card = new RiskCard(RiskCardType.INFANTRY, t);
+    assertEquals("INFANTRY", card.toString());
+  }
 }


### PR DESCRIPTION
## Description

Implements mandatory card trading through the game UI, completing the two TODO comments in GameController. Before the implementation could be wired up, Player.removeCard(RiskCard) was missing (the CardTradePhase BVA document explicitly assigns card removal to the caller, but no such method existed).

This PR adds it through a full TDD cycle, then uses it to drive pre-turn and post-elimination trading loops in the GUI.

## Related Task

Closes #103 

---

## ✅ PR Checklist

### 🧪 Testing

- [x] All existing automated tests pass
- [x] New code is covered by tests written **before** the implementation (TDD/BDD)
- [x] Test inputs and assertions are based on BVA analysis
- [x] Mutation testing has been run — **100% of non-equivalent mutants are killed**
- [x] **100% cyclomatic coverage** for all non-GUI and non-enum code
- [x] Integration tests updated/added if this PR touches a main feature (at least 2 main features must have integration
  tests by end of project) (Added in previous commit)

### 🎨 Code Quality

- [x] Code fully satisfies the team's agreed style standards
- [x] Code follows **Clean Code** principles (meaningful names, small functions, no dead code, etc.)
- [x] No unnecessary comments and minimal TODOs left in

### 🌍 Localization (i18n)

- [x] Any new user-facing strings are externalized (not hardcoded)
- [x] Adding this change does not require modifying existing locale files to support a new language

### 🔁 Process

- [x] The corresponding task on the project management board is updated with a **detailed description**
- [x] This week's planning/progress notes are up to date in the team's documentation
- [x] This PR targets the correct branch and is **not** a direct push to `main`
- [x] CI pipeline passes ✅

---

## 📸 Screenshots / Evidence (if applicable)

Automated tests pass
<img width="900" height="353" alt="Screenshot 2026-06-10 at 11 45 01 PM" src="https://github.com/user-attachments/assets/d1c1e0ee-7007-4219-b9b6-8692d19e8a04" />

Pitest pass
<img width="627" height="269" alt="Screenshot 2026-06-10 at 11 46 02 PM" src="https://github.com/user-attachments/assets/4a14f334-8091-4e13-b2d2-719ad31446eb" />

Jacoco pass
<img width="851" height="482" alt="Screenshot 2026-06-10 at 11 45 38 PM" src="https://github.com/user-attachments/assets/84020679-4d26-46f9-b38d-719a14c4ae2a" />

SpotBugs main and test pass
<img width="461" height="566" alt="Screenshot 2026-06-10 at 11 46 46 PM" src="https://github.com/user-attachments/assets/b0bca2f3-426c-4cc2-9303-819e8d6760d2" />

<img width="441" height="569" alt="Screenshot 2026-06-10 at 11 46 31 PM" src="https://github.com/user-attachments/assets/9fff5216-816b-4038-8157-f1704d6e896b" />
